### PR TITLE
Make git ignore files that are dynamically generated by Hydrus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+### Compiled Python detritus
+__pycache__/
+*.py[cod]
+
+### IDE's
+
+## IntelliJ and related IDE's (RubyMine, PhpStorm, AppCode, PyCharm)
+*.iml
+
+# Directory-based project format:
+.idea/
+
+
+## Eclipse
+*.pydevproject
+.metadata
+.gradle
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+
+# Eclipse Core
+.project
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+### Some rules to keep out installation-specific stuff that's generated when Hydrus is run from source
+temp/
+export/
+logs/
+crash.log
+db/

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ __pycache__/
 *.pydevproject
 .metadata
 .gradle
-bin/
 tmp/
 *.tmp
 *.bak


### PR DESCRIPTION
This'll make git's output it a lot less messy updating with the client using git while running from source or developing ;)