### PR TITLE
'ascii' codec can't encode character u'\xa0'

### DIFF
--- a/include/ClientData.py
+++ b/include/ClientData.py
@@ -2341,7 +2341,7 @@ class Service( HydrusData.HydrusYAMLBase ):
             
             job_key.SetVariable( 'popup_text_1', updates_text + ', and ' + content_text )
             
-            print( job_key.ToString() )
+            print( job_key.ToString().encode( 'utf-8' ) )
             
             time.sleep( 3 )
             


### PR DESCRIPTION
Another Unicode problem that was in there for a quite some time. At the end of each sync session, a summary is printed to log:

```
job_key.SetVariable( 'popup_title', 'repository synchronisation - ' + self._name + ' - finished' )
            
updates_text = HydrusData.ConvertIntToPrettyString( num_updates_downloaded ) + ' updates downloaded, ' + HydrusData.ConvertIntToPrettyString( num_updates_processed ) + ' updates processed'
            
if self._service_type == HC.TAG_REPOSITORY: content_text = HydrusData.ConvertIntToPrettyString( total_content_weight_processed ) + ' mappings added'
elif self._service_type == HC.FILE_REPOSITORY: content_text = HydrusData.ConvertIntToPrettyString( total_content_weight_processed ) + ' files added'
            
job_key.SetVariable( 'popup_text_1', updates_text + ', and ' + content_text )
            
print( job_key.ToString() )
```

Unfortunately, here's what happens on some locales:

> Traceback (most recent call last):
  File "C:\code\Hydrus\build\client\out00-PYZ.pyz\include.ClientData", line 2344, in Sync
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 112: ordinal not in range(128)

> Failed to update public tag repository:

> The following exception occured at 2015/11/14 05:41:55:
UnicodeEncodeError

> 'ascii' codec can't encode character u'\xa0' in position 112: ordinal not in range(128)

> Traceback (most recent call last):
  File "C:\code\Hydrus\build\client\out00-PYZ.pyz\include.ClientData", line 2344, in Sync
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 112: ordinal not in range(128)

The fix attached to this pull request should take care of that problem. This is very important to fix as the bug causes GUI to display error titled "Failed to update public tag repository" which can be misleading.