### PR TITLE
Convenience constants for package maintainers

### DIFF
--- a/client.py
+++ b/client.py
@@ -38,14 +38,14 @@ try:
     
     if result.db_dir is None:
         
-        db_dir = os.path.join( HC.BASE_DIR, 'db' )
+        db_dir = os.path.join( HC.USERDATA_DIR, 'db' )
         
     else:
         
         db_dir = result.db_dir
         
     
-    db_dir = HydrusPaths.ConvertPortablePathToAbsPath( db_dir, HC.BASE_DIR )
+    db_dir = HydrusPaths.ConvertPortablePathToAbsPath( db_dir, HC.USERDATA_DIR )
     
     try:
         

--- a/client.pyw
+++ b/client.pyw
@@ -38,14 +38,14 @@ try:
     
     if result.db_dir is None:
         
-        db_dir = os.path.join( HC.BASE_DIR, 'db' )
+        db_dir = os.path.join( HC.USERDATA_DIR, 'db' )
         
     else:
         
         db_dir = result.db_dir
         
     
-    db_dir = HydrusPaths.ConvertPortablePathToAbsPath( db_dir, HC.BASE_DIR )
+    db_dir = HydrusPaths.ConvertPortablePathToAbsPath( db_dir, HC.USERDATA_DIR )
     
     try:
         

--- a/include/ClientDB.py
+++ b/include/ClientDB.py
@@ -8300,7 +8300,7 @@ class DB( HydrusDB.HydrusDB ):
                         
                         tas_flat = info[ 'tag_archive_sync' ].items()
                         
-                        info[ 'tag_archive_sync' ] = { HydrusPaths.ConvertAbsPathToPortablePath( os.path.join( client_archives_folder, archive_name + '.db', HC.BASE_DIR ) ) : namespaces for ( archive_name, namespaces ) in tas_flat }
+                        info[ 'tag_archive_sync' ] = { HydrusPaths.ConvertAbsPathToPortablePath( os.path.join( client_archives_folder, archive_name + '.db', HC.USERDATA_DIR ) ) : namespaces for ( archive_name, namespaces ) in tas_flat }
                         
                         self._c.execute( 'UPDATE services SET info = ? WHERE service_id = ?;', ( info, service_id ) )
                         
@@ -8428,7 +8428,7 @@ class DB( HydrusDB.HydrusDB ):
                 self._c.execute( 'INSERT INTO client_files_locations ( prefix, location ) VALUES ( ?, ? );', ( 't' + prefix, location ) )
                 self._c.execute( 'INSERT INTO client_files_locations ( prefix, location ) VALUES ( ?, ? );', ( 'r' + prefix, location ) )
                 
-                location = HydrusPaths.ConvertPortablePathToAbsPath( location, HC.BASE_DIR )
+                location = HydrusPaths.ConvertPortablePathToAbsPath( location, HC.USERDATA_DIR )
                 
                 text_prefix = 'rearranging client files: ' + HydrusData.ConvertValueRangeToPrettyString( i + 1, 256 ) + ', '
                 
@@ -8498,7 +8498,7 @@ class DB( HydrusDB.HydrusDB ):
                     
                 else:
                     
-                    a_p = os.path.normpath( os.path.join( HC.BASE_DIR, p ) )
+                    a_p = os.path.normpath( os.path.join( HC.USERDATA_DIR, p ) )
                     
                 
                 if not HC.PLATFORM_WINDOWS and not os.path.exists( a_p ):

--- a/include/ClientData.py
+++ b/include/ClientData.py
@@ -512,7 +512,7 @@ class ClientOptions( HydrusSerialisable.SerialisableBase ):
         
         if db_dir is None:
             
-            db_dir = os.path.join( HC.BASE_DIR, 'db' )
+            db_dir = os.path.join( HC.USERDATA_DIR, 'db' )
             
         
         self._dictionary = HydrusSerialisable.SerialisableDictionary()
@@ -746,7 +746,7 @@ class ClientOptions( HydrusSerialisable.SerialisableBase ):
                     
                 else:
                     
-                    a_p = os.path.normpath( os.path.join( HC.BASE_DIR, p ) )
+                    a_p = os.path.normpath( os.path.join( HC.USERDATA_DIR, p ) )
                     
                 
                 if not HC.PLATFORM_WINDOWS and not os.path.exists( a_p ):

--- a/include/ClientGUI.py
+++ b/include/ClientGUI.py
@@ -224,7 +224,7 @@ class FrameGUI( ClientGUITopLevelWindows.FrameThatResizes ):
         
         aboutinfo.SetDescription( description )
         
-        with open( os.path.join( HC.BASE_DIR, 'license.txt' ), 'rb' ) as f: license = f.read()
+        with open( os.path.join( HC.LICENSE_DIR, 'license.txt' ), 'rb' ) as f: license = f.read()
         
         aboutinfo.SetLicense( license )
         

--- a/include/HydrusConstants.py
+++ b/include/HydrusConstants.py
@@ -24,7 +24,9 @@ BIN_DIR = os.path.join( BASE_DIR, 'bin' )
 HELP_DIR = os.path.join( BASE_DIR, 'help' )
 INCLUDE_DIR = os.path.join( BASE_DIR, 'include' )
 STATIC_DIR = os.path.join( BASE_DIR, 'static' )
+
 USERDATA_DIR = BASE_DIR
+LICENSE_DIR = BASE_DIR
 
 #
 

--- a/include/HydrusConstants.py
+++ b/include/HydrusConstants.py
@@ -24,6 +24,7 @@ BIN_DIR = os.path.join( BASE_DIR, 'bin' )
 HELP_DIR = os.path.join( BASE_DIR, 'help' )
 INCLUDE_DIR = os.path.join( BASE_DIR, 'include' )
 STATIC_DIR = os.path.join( BASE_DIR, 'static' )
+USERDATA_DIR = BASE_DIR
 
 #
 

--- a/server.py
+++ b/server.py
@@ -46,14 +46,14 @@ try:
     
     if result.db_dir is None:
         
-        db_dir = os.path.join( HC.BASE_DIR, 'db' )
+        db_dir = os.path.join( HC.USERDATA_DIR, 'db' )
         
     else:
         
         db_dir = result.db_dir
         
     
-    db_dir = HydrusPaths.ConvertPortablePathToAbsPath( db_dir, HC.BASE_DIR )
+    db_dir = HydrusPaths.ConvertPortablePathToAbsPath( db_dir, HC.USERDATA_DIR )
     
     try:
         


### PR DESCRIPTION
This adds the USERDATA_DIR and LICENSE_DIR constants for package maintainers to modify when installing hydrus to a directory it doesn't have permissions to write to.