### PR TITLE
Compact JSON in HydrusSerialisable.DumpToString()

### DIFF
--- a/include/HydrusSerialisable.py
+++ b/include/HydrusSerialisable.py
@@ -190,7 +190,7 @@ class SerialisableBase( object ):
         
         obj_tuple = self.GetSerialisableTuple()
         
-        return json.dumps( obj_tuple )
+        return json.dumps( obj_tuple,separators=(',', ':') )
         
     
     def Duplicate( self ):


### PR DESCRIPTION
Versions of python prior to 3.4 add unnecessary extra space between separators.