### PR TITLE
Added LoliSnatcherDroid and Animeboxes note clarity to clients

### DIFF
--- a/help/client_api.html
+++ b/help/client_api.html
@@ -18,7 +18,8 @@
 			<ul>
 				<li><a href="https://gitgud.io/prkc/hydrus-companion">https://gitgud.io/prkc/hydrus-companion</a> - Hydrus Companion, a Chrome/Firefox extension for hydrus that allows easy download queueing as you browse and advanced login support</li>
 				<li><a href="https://github.com/floogulinc/hydrus-web">https://github.com/floogulinc/hydrus-web</a> - Hydrus Web, a web client for hydrus (allows phone browsing of hydrus)</li>
-				<li><a href="https://www.animebox.es/">https://www.animebox.es/</a> - Anime Boxes now supports adding your client as a Hydrus Server</li>
+				<li><a href="https://github.com/NO-ob/LoliSnatcher_Droid">https://github.com/NO-ob/LoliSnatcher_Droid</a> - Loli-Snatcher Droid, a FLOSS (GPLv3) Android booru browser that allows browsing hydrus.
+				<li><a href="https://www.animebox.es/">https://www.animebox.es/</a> - Anime Boxes, a closed source booru browser now supports adding your client as a Hydrus Server</li>
 				<li><a href="https://gitgud.io/koto/hydrus-archive-delete">https://gitgud.io/koto/hydrus-archive-delete</a> - Archive/Delete filter in your web browser</li>
 				<li><a href="https://gitgud.io/koto/hydrus-dd">https://gitgud.io/koto/hydrus-dd</a> - DeepDanbooru neural network tagging for Hydrus</li>
 				<li><a href="https://gitgud.io/prkc/dolphin-hydrus-actions">https://gitgud.io/prkc/dolphin-hydrus-actions</a> - Adds Hydrus right-click context menu actions to Dolphin file manager.</li>


### PR DESCRIPTION
Added LoliSnatcher Droid to the list of clients, as well as changed the note on Anime boxes.
Made a clear distinction that Animeboxes is closed source, and LoliSnatcher Droid is FLOSS under GPLv3.