### PR TITLE
Update the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,5 @@
 name: Bug report
 description: File a bug report
-title: "[Bug]: "
 labels: [bug]
 
 body:
@@ -14,7 +13,7 @@ body:
       id: hydrus_version
       attributes:
         label: Hydrus version
-        description: Your version of Hydrus. Kindly update to the latest version before filing a report.
+        description: You can find this in the about page from the "help" menu. Kindly update to the latest version before filing a report.
         placeholder: v447 or just 447 are both acceptable.
       validations:
         required: true
@@ -27,12 +26,12 @@ body:
         options:
           - Windows 10
           - Windows 11
-          - Windows, older. (Specify in comments)
-          - MacOS 11 "Big Sur" x86
-          - MacOS 11 "Big Sur" ARM
-          - MacOS 10.15 "Catalina"
-          - MacOS, older (Specify in comments)
-          - Linux (Specify distro and version in comments)
+          - Windows other (specify in comments)
+          - macOS 11 "Big Sur" (Apple silicon)
+          - macOS 11 "Big Sur" (Intel)
+          - macOS 10.15 "Catalina"
+          - macOS other (specify in comments)
+          - Linux (specify distro and version in comments)
           - Other (aka none of the above, specify in the comments)
       validations:
         required: true
@@ -73,5 +72,5 @@ body:
       id: logs
       attributes:
         label: Log output
-        description: Either copypaste relevant log sections here or upload the file in the bug description above.
-        render: shell
+        description: Either copy and paste relevant log sections here or upload the file in the bug description above.
+        render: text


### PR DESCRIPTION
Mostly some grammar and content changes. Mainly stuff I didn't catch when originally reviewing it.

- Removes the preset title.
- Adds instructions to the version field.
- Changes from "older" to "other" in OS options for when new versions come out and we haven't updated the template or people are running betas.
- Changes log rendering to plain text rather than shell syntax highlighting.
- Corrects some terminology for macOS.