### PR TITLE
Simplify PHash ARGB to Gray math

### DIFF
--- a/hydrus/client/ClientImageHandling.py
+++ b/hydrus/client/ClientImageHandling.py
@@ -61,17 +61,13 @@ def GenerateShapePerceptualHashes( path, mime ):
         
         numpy_alpha_float = numpy_alpha / 255.0
         
-        numpy_image_bgr = numpy_image[ :, :, :3 ]
+        numpy_alpha_inverted = 255.0 - numpy_alpha
         
-        numpy_image_gray_bare = cv2.cvtColor( numpy_image_bgr, cv2.COLOR_RGB2GRAY )
+        numpy_image_gray_bare = cv2.cvtColor( numpy_image, cv2.COLOR_RGB2GRAY )
         
-        # create a white greyscale canvas
+        # paste the grayscale image onto the white canvas using: pixel * alpha + inverted_alpha
         
-        white = numpy.ones( ( y, x ) ) * 255.0
-        
-        # paste the grayscale image onto the white canvas using: pixel * alpha + white * ( 1 - alpha )
-        
-        numpy_image_gray = numpy.uint8( ( numpy_image_gray_bare * numpy_alpha_float ) + ( white * ( numpy.ones( ( y, x ) ) - numpy_alpha_float ) ) )
+        numpy_image_gray = numpy.uint8( ( numpy_image_gray_bare * numpy_alpha_float ) + numpy_alpha_inverted )
         
     else:
         


### PR DESCRIPTION
There is no need to extract RGB channels before doing cvtcolor(cv2.COLOR_RGB2GRAY)

Remove overcomplicated way of applying inverted alpha to alpha multiplied by grayscale:
Instead of creating a white canvas and subtracting the alpha from it, we can just invert the alpha sub subtracting it from 255.0

You can see the difference between the old and new here:
Old method:
![old_gray](https://user-images.githubusercontent.com/26223094/128608613-a3d55ccb-9223-4878-b608-4d64c3a87ef3.png)
New method: 
![new_gray](https://user-images.githubusercontent.com/26223094/128608617-4ec92d3d-c392-4fa8-8dfe-6caac1ca4a34.png)

Here is the different in DCT results: (DCT and DCT_88)
Old:
![old_dct](https://user-images.githubusercontent.com/26223094/128608661-4d55461f-f470-460f-8a4e-1485cb09e112.png)
![old_dct_roi](https://user-images.githubusercontent.com/26223094/128608665-3b7abfea-7d83-4397-b204-e2c688ac74b6.png)
New:
![new_dct](https://user-images.githubusercontent.com/26223094/128608670-ca54028c-db46-420d-875a-3f0240805c2a.png)
![new_dct_roi](https://user-images.githubusercontent.com/26223094/128608672-c8e253c0-f940-4c9a-8f8e-d09e57370172.png)

And finally the phashes:
old: c444b1f236bdc995
new: c444b1f236bdc995

The test image i used:
![test image](https://user-images.githubusercontent.com/26223094/128608734-f2210b78-7f56-4541-9aae-cf18e5377efc.png)
