### PR TITLE
Update OpenCV build info

### DIFF
--- a/static/build_files/linux/requirements.txt
+++ b/static/build_files/linux/requirements.txt
@@ -6,7 +6,7 @@ lxml>=4.5.0
 lz4>=3.0.0
 nose>=1.3.0
 numpy>=1.16.0
-opencv-python-headless==4.5.3.56
+opencv-python-headless>=4.0.0, <=4.5.3.56
 Pillow>=6.0.0
 psutil>=5.0.0
 pylzma>=0.5.0

--- a/static/build_files/macos/requirements.txt
+++ b/static/build_files/macos/requirements.txt
@@ -6,7 +6,7 @@ lxml>=4.5.0
 lz4>=3.0.0
 nose>=1.3.0
 numpy>=1.16.0
-opencv-python-headless==4.5.3.56
+opencv-python-headless>=4.0.0, <=4.5.3.56
 Pillow>=6.0.0
 psutil>=5.0.0
 pylzma>=0.5.0

--- a/static/build_files/windows/client-win.spec
+++ b/static/build_files/windows/client-win.spec
@@ -1,12 +1,10 @@
 # -*- mode: python ; coding: utf-8 -*-
 
 import cloudscraper
-import cv2
 import shiboken2
 import os
 import glob
 cloudscraper_dir = os.path.dirname( cloudscraper.__file__ )
-cv2_ffmpeg_dll = glob.glob(os.path.dirname( cv2.__file__ )+"/*.dll")[0]
 shiboken_dir = os.path.join( os.path.dirname( shiboken2.__file__ ), 'files.dir' )
 
 block_cipher = None
@@ -28,8 +26,7 @@ a = Analysis(['hydrus\\client.pyw'],
                ('hydrus\\sqlite3.dll', '.'),
                ('hydrus\\mpv-1.dll', '.'),
                (cloudscraper_dir, 'cloudscraper'),
-               (shiboken_dir, 'shiboken2\\files.dir'),
-               (cv2_ffmpeg_dll, '.')
+               (shiboken_dir, 'shiboken2\\files.dir')
              ],
              hiddenimports=['hydrus\\server.py', 'cloudscraper'],
              hookspath=[],

--- a/static/build_files/windows/requirements.txt
+++ b/static/build_files/windows/requirements.txt
@@ -1,7 +1,3 @@
-PyWin32
-pypiwin32
-pywin32-ctypes
-pefile
 beautifulsoup4>=4.0.0
 chardet>=3.0.4
 cloudscraper>=1.2.33
@@ -10,7 +6,7 @@ lxml>=4.5.0
 lz4>=3.0.0
 nose>=1.3.0
 numpy>=1.16.0
-opencv-python-headless==4.5.3.56
+opencv-python-headless>=4.0.0, <=4.5.3.56
 Pillow>=6.0.0
 psutil>=5.0.0
 pylzma>=0.5.0
@@ -25,3 +21,7 @@ Send2Trash>=1.5.0
 service-identity>=18.1.0
 six>=1.14.0
 Twisted>=20.3.0
+PyWin32
+pypiwin32
+pywin32-ctypes
+pefile


### PR DESCRIPTION
Set new cv version in requirements.txt since PyInstaller doesn't support 4.5.4.58 yet and no longer bundling cv dll in windows (as pyinstaller now does this correct)