### PR TITLE
Add Publisher and Version to Control Panel Entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
         name: InnoSetup
         run: |
           move hydrus\static\build_files\windows\InnoSetup.iss InnoSetup.iss
-          ISCC.exe InnoSetup.iss
+          ISCC.exe InnoSetup.iss /DVersion=${GITHUB_REF#refs/*/}
       -
         name: Compress Client
         run: |

--- a/static/build_files/windows/InnoSetup.iss
+++ b/static/build_files/windows/InnoSetup.iss
@@ -13,6 +13,7 @@ OutputBaseFilename=HydrusInstaller
 Compression=lzma/ultra64
 AppName=Hydrus Network
 AppVerName=Hydrus Network
+AppPublisher=Hydrus Network
 DefaultDirName={sd}\Hydrus Network
 DefaultGroupName=Hydrus Network
 DisableProgramGroupPage=yes

--- a/static/build_files/windows/InnoSetup.iss
+++ b/static/build_files/windows/InnoSetup.iss
@@ -1,3 +1,7 @@
+#ifndef Version
+    #define Version "vNull"
+#endif
+
 [Icons]
 Name: {group}\hydrus client; Filename: {app}\client.exe; WorkingDir: {app}; Tasks: programgroupicons
 Name: {group}\hydrus server; Filename: {app}\server.exe; WorkingDir: {app}; Tasks: programgroupicons
@@ -14,6 +18,7 @@ Compression=lzma/ultra64
 AppName=Hydrus Network
 AppVerName=Hydrus Network
 AppPublisher=Hydrus Network
+AppVersion={#Version}
 DefaultDirName={sd}\Hydrus Network
 DefaultGroupName=Hydrus Network
 DisableProgramGroupPage=yes

--- a/static/build_files/windows/windows_build.yml
+++ b/static/build_files/windows/windows_build.yml
@@ -73,7 +73,7 @@ jobs:
         name: InnoSetup
         run: |
           move hydrus\static\build_files\windows\InnoSetup.iss InnoSetup.iss
-          ISCC.exe InnoSetup.iss
+          ISCC.exe InnoSetup.iss /DVersion=${GITHUB_REF#refs/*/}
       -
         name: Compress Client
         run: |


### PR DESCRIPTION
This change should add the publisher and app version to the Control Panel Entry when Hydrus Network is installed on Windows. 

It uses the Tag name provided for the release as the version number.