### PR TITLE
added an api endpoint to search tag suggestions

### DIFF
--- a/docs/developer_api.md
+++ b/docs/developer_api.md
@@ -451,7 +451,50 @@ Response:
 
     !!! note
         A user can rename their services. Don't assume the client's local tags service will be "my tags".
-    
+
+### **GET `/add_tags/search_tags`** { id="add_tags_search_tags" }
+
+_Ask the client for tag suggestions._
+
+Restricted access:
+:   YES. Search for Files permission needed.
+
+Required Headers: n/a
+
+Arguments:
+:   
+* `search`: (the tag to search for)
+* `tag_service_key`: (optional, selective, hexadecimal, the tag domain on which to search)
+* `tag_service_name`: (optional, selective, string, the tag domain on which to search)
+
+Example request:
+:   
+```http title="Example request"
+/add_tags/search_tags?search=kim
+```
+
+Response:
+:   Some JSON listing the client's suggested tags.
+
+:   
+```json title="Example response"
+{
+  "tags": [
+    {
+      "value": "kim possible", 
+      "count": 2
+    },
+    {
+      "value": "character:kim possible", 
+      "count": 1
+    },
+    {
+      "value": "series:kim possible", 
+      "count": 3
+    }
+  ]
+}
+```
 
 ### **POST `/add_tags/add_tags`** { id="add_tags_add_tags" }
 

--- a/hydrus/client/networking/ClientLocalServer.py
+++ b/hydrus/client/networking/ClientLocalServer.py
@@ -64,6 +64,7 @@ class HydrusServiceClientAPI( HydrusClientService ):
         add_tags.putChild( b'add_tags', ClientLocalServerResources.HydrusResourceClientAPIRestrictedAddTagsAddTags( self._service, self._client_requests_domain ) )
         add_tags.putChild( b'clean_tags', ClientLocalServerResources.HydrusResourceClientAPIRestrictedAddTagsCleanTags( self._service, self._client_requests_domain ) )
         add_tags.putChild( b'get_tag_services', ClientLocalServerResources.HydrusResourceClientAPIRestrictedAddTagsGetTagServices( self._service, self._client_requests_domain ) )
+        add_tags.putChild( b'search_tags', ClientLocalServerResources.HydrusResourceClientAPIRestrictedAddTagsSearchTags( self._service, self._client_requests_domain ) )
         
         add_urls = NoResource()
         


### PR DESCRIPTION
**Problem**
External applications and plugins have no simple way to get suggested tags.

**What**
This exposes the tag suggestion behavior found in the UI's tag manager through the client api.

**Assumptions**
I tried to keep to the existing code and endpoint styles as I could. I would typically put this endpoint at something like `/tags?search=foo`, so let me know if it should be exposed differently.

Another assumption was to not categorize the tags by tag service in the response. This was because it can be passed as a tag key/name filter to narrow the results. If categories based on tag service is desired, it could be added here to avoid future breaking changes.