### PR TITLE
 Short Cache-Control header for dynamic pages

### DIFF
--- a/hydrus/core/networking/HydrusServerResources.py
+++ b/hydrus/core/networking/HydrusServerResources.py
@@ -675,6 +675,7 @@ class HydrusResource( Resource ):
             request.setHeader( 'Content-Type', content_type )
             request.setHeader( 'Content-Length', str( content_length ) )
             request.setHeader( 'Content-Disposition', content_disposition )
+            request.setHeader( 'Cache-Control', 'max-age={}'.format( 4 ) ) #hydurs won't change its mind about dynamic data under 4 seconds even if you ask repeatedly
             
             request.write( body_bytes )
             


### PR DESCRIPTION
Letting the caller know that a response is valid for 4 seconds makes them a lot less chatty with hydrus which significantly boosts responsiveness, on both client side and means that the caller can bother hydrus less.

If we're being honest this is mostly to stop Hydrus-Companion from asking about URL status so often, since only web browsers look at cache control anyway.  Depending on web browser hydrus companion can send a request to get url info up to 6 times just for loading a page, and this really adds up.  Also it will re ask when cycling tabs or windows back into focus even if you were just looking at them.

4 seconds is a decent compromise between treating the page as dynamic and realizing that hydrus mostly won't change its ind in under 4 seconds.  If a browser extension wants to bypass that it can do so by properly configuring the `xhr`