### PR TITLE
Export filename can be numbered by arbitrary sort

### DIFF
--- a/hydrus/client/exporting/ClientExportingFiles.py
+++ b/hydrus/client/exporting/ClientExportingFiles.py
@@ -22,7 +22,7 @@ from hydrus.client.metadata import ClientTagSorting
 
 MAX_PATH_LENGTH = 240 # bit of padding from 255 for .txt neigbouring and other surprises
 
-def GenerateExportFilename( destination_directory, media, terms, do_not_use_filenames = None ):
+def GenerateExportFilename( destination_directory, media, terms, count, do_not_use_filenames = None ):
     
     def clean_tag_text( t ):
         
@@ -92,7 +92,10 @@ def GenerateExportFilename( destination_directory, media, terms, do_not_use_file
                 hash_id = media.GetHashId()
                 
                 filename += str( hash_id )
-                
+
+            elif term == '#':
+
+                filename += str( count )
             
         elif term_type == 'tag':
             

--- a/hydrus/client/gui/ClientGUIExport.py
+++ b/hydrus/client/gui/ClientGUIExport.py
@@ -955,8 +955,10 @@ class ReviewExportFilesPanel( ClientGUIScrolledPanels.ReviewPanel ):
         pattern = self._pattern.text()
         
         terms = ClientExportingFiles.ParseExportPhrase( pattern )
+
+        count = len(self._media_to_paths) + 1
         
-        filename = ClientExportingFiles.GenerateExportFilename( directory, media, terms, do_not_use_filenames = self._existing_filenames )
+        filename = ClientExportingFiles.GenerateExportFilename( directory, media, terms, count, do_not_use_filenames = self._existing_filenames )
         
         path = os.path.join( directory, filename )
         

--- a/hydrus/client/gui/widgets/ClientGUICommon.py
+++ b/hydrus/client/gui/widgets/ClientGUICommon.py
@@ -1009,6 +1009,7 @@ class ExportPatternButton( BetterButton ):
         ClientGUIMenus.AppendMenuItem( menu, 'the file\'s hash - {hash}', 'copy "{hash}" to the clipboard', HG.client_controller.pub, 'clipboard', 'text', '{hash}' )
         ClientGUIMenus.AppendMenuItem( menu, 'all the file\'s tags - {tags}', 'copy "{tags}" to the clipboard', HG.client_controller.pub, 'clipboard', 'text', '{tags}' )
         ClientGUIMenus.AppendMenuItem( menu, 'all the file\'s non-namespaced tags - {nn tags}', 'copy "{nn tags}" to the clipboard', HG.client_controller.pub, 'clipboard', 'text', '{nn tags}' )
+        ClientGUIMenus.AppendMenuItem( menu, 'file order - {#}', 'copy "{#}" to the clipboard', HG.client_controller.pub, 'clipboard', 'text', '{#}' )
         
         ClientGUIMenus.AppendSeparator( menu )
         


### PR DESCRIPTION
Implements `{#}` as an export term that can add an incrementing number to the filename, so that files can be given a filename that sorts based on any arbitrary sorting that is done in hydrus. Very useful for exporting comics or image sets that don't already have a `[page]` namespace and were not imported in order. 