### PR TITLE
Add generic .desktop file

### DIFF
--- a/static/hydrus.desktop
+++ b/static/hydrus.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=Hydrus Client
+Comment=Danbooru-like image tagging and searching system for the desktop
+Exec=hydrus-client
+Icon=/usr/lib/hydrus/static/hydrus_non-transparent.png
+Terminal=false
+Type=Application
+Categories=Application;FileTools;Graphics;Network;


### PR DESCRIPTION
Intention is to add this generic .desktop file for linux users, so we don't have to either create it ourselves or launch hydrus from terminal.

Exec path could be subject to change, but every linux package i've seen wraps client.pyw to an executable called hydrus-client (or -server) somewhere in $PATH, so this should work.