### PR TITLE
Add support for audio comparison in duplicate processing

### DIFF
--- a/hydrus/client/ClientDuplicates.py
+++ b/hydrus/client/ClientDuplicates.py
@@ -51,6 +51,7 @@ def GetDuplicateComparisonStatements( shown_media, comparison_media ):
     duplicate_comparison_score_more_tags = new_options.GetInteger( 'duplicate_comparison_score_more_tags' )
     duplicate_comparison_score_older = new_options.GetInteger( 'duplicate_comparison_score_older' )
     duplicate_comparison_score_nicer_ratio = new_options.GetInteger( 'duplicate_comparison_score_nicer_ratio' )
+    duplicate_comparison_score_has_audio = new_options.GetInteger( 'duplicate_comparison_score_has_audio' )
     
     #
     
@@ -317,8 +318,30 @@ def GetDuplicateComparisonStatements( shown_media, comparison_media ):
         score = 0
         
         statements_and_scores[ 'mime' ] = ( statement, score )
+
+
+    # audio/no audio
+
+    s_has_audio = shown_media.GetMediaResult().HasAudio()
+    c_has_audio = comparison_media.GetMediaResult().HasAudio()
+
+    if s_has_audio != c_has_audio:
         
+        if s_has_audio:
+
+            audio_statement = 'has audio, the other does not'
+            score = duplicate_comparison_score_has_audio
+
+        else:
+            
+            audio_statement = 'the other has audio, this does not'
+            score = 0
+        
+        statement = '{} vs {}'.format( s_has_audio, c_has_audio )
+
+        statements_and_scores[ 'has_audio' ] = ( audio_statement, score )
     
+
     # more tags
     
     s_num_tags = len( shown_media.GetTagsManager().GetCurrentAndPending( CC.COMBINED_TAG_SERVICE_KEY, ClientTags.TAG_DISPLAY_ACTUAL ) )

--- a/hydrus/client/ClientOptions.py
+++ b/hydrus/client/ClientOptions.py
@@ -455,6 +455,7 @@ class ClientOptions( HydrusSerialisable.SerialisableBase ):
         self._dictionary[ 'integers' ][ 'duplicate_comparison_score_more_tags' ] = 8
         self._dictionary[ 'integers' ][ 'duplicate_comparison_score_older' ] = 4
         self._dictionary[ 'integers' ][ 'duplicate_comparison_score_nicer_ratio' ] = 10
+        self._dictionary[ 'integers' ][ 'duplicate_comparison_score_has_audio' ] = 20
         
         self._dictionary[ 'integers' ][ 'thumbnail_cache_size' ] = 1024 * 1024 * 32
         self._dictionary[ 'integers' ][ 'image_cache_size' ] = 1024 * 1024 * 384

--- a/hydrus/client/gui/ClientGUIScrolledPanelsManagement.py
+++ b/hydrus/client/gui/ClientGUIScrolledPanelsManagement.py
@@ -685,6 +685,7 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             self._duplicate_comparison_score_more_tags = ClientGUICommon.BetterSpinBox( weights_panel, min=-100, max=100 )
             self._duplicate_comparison_score_older = ClientGUICommon.BetterSpinBox( weights_panel, min=-100, max=100 )
             self._duplicate_comparison_score_nicer_ratio = ClientGUICommon.BetterSpinBox( weights_panel, min=-100, max=100 )
+            self._duplicate_comparison_score_has_audio = ClientGUICommon.BetterSpinBox( weights_panel, min=-100, max=100 )
             
             self._duplicate_comparison_score_nicer_ratio.setToolTip( 'For instance, 16:9 vs 640:357.')
             
@@ -714,6 +715,7 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             self._duplicate_comparison_score_more_tags.setValue( self._new_options.GetInteger( 'duplicate_comparison_score_more_tags' ) )
             self._duplicate_comparison_score_older.setValue( self._new_options.GetInteger( 'duplicate_comparison_score_older' ) )
             self._duplicate_comparison_score_nicer_ratio.setValue( self._new_options.GetInteger( 'duplicate_comparison_score_nicer_ratio' ) )
+            self._duplicate_comparison_score_has_audio.setValue( self._new_options.GetInteger( 'duplicate_comparison_score_has_audio' ) )
             
             self._duplicate_filter_max_batch_size.setValue( self._new_options.GetInteger( 'duplicate_filter_max_batch_size' ) )
             
@@ -734,6 +736,7 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             rows.append( ( 'Score for file with more tags:', self._duplicate_comparison_score_more_tags ) )
             rows.append( ( 'Score for file with non-trivially earlier import time:', self._duplicate_comparison_score_older ) )
             rows.append( ( 'Score for file with \'nicer\' resolution ratio:', self._duplicate_comparison_score_nicer_ratio ) )
+            rows.append( ( 'Score for file with audio:', self._duplicate_comparison_score_has_audio ) )
             
             gridbox = ClientGUICommon.WrapInGrid( weights_panel, rows )
             
@@ -798,6 +801,7 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             self._new_options.SetInteger( 'duplicate_comparison_score_more_tags', self._duplicate_comparison_score_more_tags.value() )
             self._new_options.SetInteger( 'duplicate_comparison_score_older', self._duplicate_comparison_score_older.value() )
             self._new_options.SetInteger( 'duplicate_comparison_score_nicer_ratio', self._duplicate_comparison_score_nicer_ratio.value() )
+            self._new_options.SetInteger( 'duplicate_comparison_score_has_audio', self._duplicate_comparison_score_has_audio.value() )
             
             self._new_options.SetInteger( 'duplicate_filter_max_batch_size', self._duplicate_filter_max_batch_size.value() )
             

--- a/hydrus/client/gui/canvas/ClientGUICanvasHoverFrames.py
+++ b/hydrus/client/gui/canvas/ClientGUICanvasHoverFrames.py
@@ -2035,7 +2035,7 @@ class CanvasHoverFrameRightDuplicates( CanvasHoverFrame ):
     def _ResetComparisonStatements( self ):
         
         statements_and_scores = ClientDuplicates.GetDuplicateComparisonStatements( self._current_media, self._comparison_media )
-
+        
         for name in self._comparison_statement_names:
             
             ( panel, st ) = self._comparison_statements_sts[ name ]

--- a/hydrus/client/gui/canvas/ClientGUICanvasHoverFrames.py
+++ b/hydrus/client/gui/canvas/ClientGUICanvasHoverFrames.py
@@ -1865,7 +1865,7 @@ class CanvasHoverFrameRightDuplicates( CanvasHoverFrame ):
         
         self._comparison_statements_vbox = QP.VBoxLayout()
         
-        self._comparison_statement_names = [ 'filesize', 'resolution', 'ratio', 'mime', 'num_tags', 'time_imported', 'jpeg_quality', 'pixel_duplicates', 'exif_data', 'embedded_metadata', 'icc_profile' ]
+        self._comparison_statement_names = [ 'filesize', 'resolution', 'ratio', 'mime', 'num_tags', 'time_imported', 'jpeg_quality', 'pixel_duplicates', 'exif_data', 'embedded_metadata', 'icc_profile', 'has_audio' ]
         
         self._comparison_statements_sts = {}
         
@@ -2035,7 +2035,7 @@ class CanvasHoverFrameRightDuplicates( CanvasHoverFrame ):
     def _ResetComparisonStatements( self ):
         
         statements_and_scores = ClientDuplicates.GetDuplicateComparisonStatements( self._current_media, self._comparison_media )
-        
+
         for name in self._comparison_statement_names:
             
             ( panel, st ) = self._comparison_statements_sts[ name ]


### PR DESCRIPTION
I recently wrote a [video deduplicator](https://github.com/appleappleapplenanner/hydrus-video-deduplicator) to mark videos as duplicates. It would be helpful to see if a video has audio and to adjust the score since videos with audio are preferred.

I believe I added all the necessary parts for this to work and it does work, but if I missed something lmk.

I know you rarely accept pull requests but I think this one is reasonable and I tried my best to follow your formatting style. I used the exif comparison as a template but I did add a score to the audio which you may or may not want to remove.

Thanks.