### PR TITLE
Add a specific check for JSON files in HydrusFileHandling.GetMime

### DIFF
--- a/hydrus/core/HydrusFileHandling.py
+++ b/hydrus/core/HydrusFileHandling.py
@@ -537,8 +537,16 @@ def GetMime( path, ok_to_look_for_hydrus_updates = False ):
                 
                 return mime
                 
-            
+    # If the file starts with '{' it is probably JSON
+    # but we can't know for sure so we send it over to be checked
+    if bit_to_check.startswith(b'{'):
         
+        with open( path, 'rb' ) as f:
+
+            if HydrusText.LooksLikeJSON(f.read()):
+
+                return HC.APPLICATION_JSON
+    
     
     if HydrusText.LooksLikeHTML( bit_to_check ):
         


### PR DESCRIPTION
This fixes some situations where FFMPEG would think a JSON file is an mpeg or whatever. This also helps prevent misidentification of SVG and HTML contained in JSON.

By first checking if the file starts with a `{` we can be conversative and only open and parse the whole file when its pretty likely to be JSON.