### PR TITLE
Improve handling of weird PSDs and log psd-tool errors

### DIFF
--- a/hydrus/core/HydrusPSDHandling.py
+++ b/hydrus/core/HydrusPSDHandling.py
@@ -81,15 +81,12 @@ def GenerateThumbnailBytesFromPSDPath( path: str, target_resolution: typing.Tupl
 def GetPSDResolution( path: str ):
     
     if not PSD_TOOLS_OK:
-        
-        return GetPSDResolutionFallback( path )
-        
+
+        raise HydrusExceptions.UnsupportedFileException( 'psd_tools unavailable' )
     
     psd = PSDImage.open( path )
-    
-    resolution = ( psd.width, psd.height )
-    
-    return resolution
+            
+    return ( psd.width, psd.height )
     
 
 def GetPSDResolutionFallback( path: str ):


### PR DESCRIPTION
We found some PSDs exported by Clip Studio don't follow the spec properly and freaks psd-tools out. 

This PR makes hydrus now always uses the PSD resolution fallback code when psd-tools fails to open a PSD instead of just when psd-tools isn't available. Also when the fallback is used for either PSD resolution or PSD thumbnail generation it is logged.
