### PR TITLE
Docs update: new filetype list, search on local help, other corrections

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -17,5 +17,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material mkdocs-redirects
+      - run: pip install mkdocs-material mkdocs-redirects mkdocs-git-revision-date-localized-plugin
       - run: mkdocs gh-deploy --force --config-file mkdocs-gh-pages.yml

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -13,8 +13,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - run: pip install mkdocs-material mkdocs-redirects mkdocs-git-revision-date-localized-plugin

--- a/docs/filetypes.md
+++ b/docs/filetypes.md
@@ -81,6 +81,7 @@ title: Supported Filetypes
 | procreate | `.procreate` | `application/x-procreate`[^1] |     ✅     |         ❌         | Procreate app     |
 
 ## Archives
+
 | Filetype | Extension | MIME type                     | Notes |
 | -------- | --------- | ----------------------------- | ----- |
 | 7z       | `.7z`     | `application/x-7z-compressed` |       |

--- a/docs/filetypes.md
+++ b/docs/filetypes.md
@@ -1,0 +1,92 @@
+---
+title: Supported Filetypes
+---
+
+
+## Images
+
+| Filetype   | Extension | MIME type      | Thumbnails | Viewable in Hydrus | Notes                                      |
+| ---------- | --------- | -------------- | :--------: | :----------------: | ------------------------------------------ |
+| jpeg       | `.jpeg`   | `image/jpeg`   |     ✅     |         ✅         |                                            |
+| png        | `.png`    | `image/png`    |     ✅     |         ✅         |                                            |
+| static gif | `.gif`    | `image/gif`    |     ✅     |         ✅         |                                            |
+| webp       | `.webp`   | `image/webp`   |     ✅     |         ✅         | Animated webp files will display as static |
+| tiff       | `.tiff`   | `image/tiff`   |     ✅     |         ✅         |                                            |
+| qoi        | `.qoi`    | `image/qoi`    |     ✅     |         ✅         | Quite OK Image Format                      |
+| icon       | `.ico`    | `image/x-icon` |     ✅     |         ✅         |                                            |
+| bmp        | `.bmp`    | `image/bmp`    |     ✅     |         ✅         | Gets converted to png                      |
+| heif       | `.heif`   | `image/heif`   |     ✅     |         ✅         |                                            |
+| heic       | `.heic`   | `image/heic`   |     ✅     |         ✅         |                                            |
+| avif       | `.avif`   | `image/avif`   |     ✅     |         ✅         |                                            |
+
+## Animations
+
+| Filetype      | Extension | MIME type             | Thumbnails | Viewable in Hydrus | Notes |
+| ------------- | --------- | --------------------- | :--------: | :----------------: | ----- |
+| animated gif  | `.gif`    | `image/gif`           |     ✅     |         ✅         |       |
+| apng          | `.apng`   | `image/apng`          |     ✅     |         ✅         |       |
+| heif sequence | `.heifs`  | `image/heif-sequence` |     ✅     |         ✅         |       |
+| heic sequence | `.heics`  | `image/heic-sequence` |     ✅     |         ✅         |       |
+| avif sequence | `.avifs`  | `image/avif-sequence` |     ✅     |         ✅         |       |
+
+## Video
+
+| Filetype  | Extension | MIME type                | Thumbnails | Viewable in Hydrus | Notes |
+| --------- | --------- | ------------------------ | :--------: | :----------------: | ----- |
+| mp4       | `.mp4`    | `video/mp4`              |     ✅     |         ✅         |       |
+| webm      | `.webm`   | `video/webm`             |     ✅     |         ✅         |       |
+| matroska  | `.mkv`    | `video/x-matroska`       |     ✅     |         ✅         |       |
+| avi       | `.avi`    | `video/x-msvideo`        |     ✅     |         ✅         |       |
+| flv       | `.flv`    | `video/x-flv`            |     ✅     |         ❌         |       |
+| quicktime | `.mov`    | `video/quicktime`        |     ✅     |         ✅         |       |
+| mpeg      | `.mpeg`   | `video/mpeg`             |     ✅     |         ✅         |       |
+| ogv       | `.ogv`    | `video/ogg`              |     ✅     |         ✅         |       |
+| realvideo | `.rm`     | `video/vnd.rn-realvideo` |     ✅     |         ✅         |       |
+| wmv       | `.wmv`    | `video/x-ms-wmv`         |     ✅     |         ✅         |       |
+
+## Audio
+
+| Filetype       | Extension | MIME type                | Viewable in Hydrus | Notes |
+| -------------- | --------- | ------------------------ | :----------------: | ----- |
+| mp3            | `.mp3`    | `audio/mp3`              |         ✅         |       |
+| ogg            | `.ogg`    | `audio/ogg`              |         ✅         |       |
+| flac           | `.flac`   | `audio/flac`             |         ✅         |       |
+| m4a            | `.m4a`    | `audio/mp4`              |         ✅         |       |
+| matroska audio | `.mkv`    | `audio/x-matroska`       |         ✅         |       |
+| mp4 audio      | `.mp4`    | `audio/mp4`              |         ✅         |       |
+| realaudio      | `.ra`     | `audio/vnd.rn-realaudio` |         ✅         |       |
+| tta            | `.tta`    | `audio/x-tta`            |         ✅         |       |
+| wave           | `.wav`    | `audio/x-wav`            |         ✅         |       |
+| wavpack        | `.wv`     | `audio/wavpack`          |         ✅         |       |
+| wma            | `.wma`    | `audio/x-ms-wma`         |         ✅         |       |
+
+## Applications
+
+| Filetype | Extension | MIME type                       | Thumbnails | Viewable in Hydrus | Notes |
+| -------- | --------- | ------------------------------- | :--------: | :----------------: | ----- |
+| flash    | `.swf`    | `application/x-shockwave-flash` |     ✅     |         ❌         |       |
+| pdf      | `.pdf`    | `application/pdf`               |     ❌     |         ❌         |       |
+
+## Image Project Files
+
+
+| Filetype  | Extension    | MIME type                     | Thumbnails | Viewable in Hydrus | Notes             |
+| --------- | ------------ | ----------------------------- | :--------: | :----------------: | ----------------- |
+| psd       | `.psd`       | `image/vnd.adobe.photoshop`   |     ✅     |         ✅         | Adobe Photoshop   |
+| clip      | `.clip`      | `application/clip`[^1]        |     ✅     |         ❌         | Clip Studio Paint |
+| sai2      | `.sai2`      | `application/sai2`[^1]        |     ❌     |         ❌         | PaintTool SAI2    |
+| krita     | `.kra`       | `application/x-krita`         |     ✅     |         ❌         |                   |
+| svg       | `.svg`       | `image/svg+xml`               |     ✅     |         ❌         |                   |
+| xcf       | `.xcf`       | `application/x-xcf`           |     ❌     |         ❌         | GIMP              |
+| procreate | `.procreate` | `application/x-procreate`[^1] |     ✅     |         ❌         | Procreate app     |
+
+## Archives
+| Filetype | Extension | MIME type                     | Notes |
+| -------- | --------- | ----------------------------- | ----- |
+| 7z       | `.7z`     | `application/x-7z-compressed` |       |
+| gzip     | `.gz`     | `application/gzip`            |       |
+| rar      | `.rar`    | `application/vnd.rar`         |       |
+| zip      | `.zip`    | `application/zip`             |       |
+
+
+[^1]: This filetype doesn't have an official or defacto media type, the one listed was made up for Hydrus.

--- a/docs/filetypes.md
+++ b/docs/filetypes.md
@@ -2,6 +2,7 @@
 title: Supported Filetypes
 ---
 
+This is a list of all filetypes Hydrus can import. Hydrus determines the filetype based on examining the file itself rather than the extension or MIME type.
 
 ## Images
 
@@ -19,6 +20,7 @@ title: Supported Filetypes
 | heic       | `.heic`   | `image/heic`   |     ✅     |         ✅         |                                            |
 | avif       | `.avif`   | `image/avif`   |     ✅     |         ✅         |                                            |
 
+
 ## Animations
 
 | Filetype      | Extension | MIME type             | Thumbnails | Viewable in Hydrus | Notes |
@@ -28,6 +30,7 @@ title: Supported Filetypes
 | heif sequence | `.heifs`  | `image/heif-sequence` |     ✅     |         ✅         |       |
 | heic sequence | `.heics`  | `image/heic-sequence` |     ✅     |         ✅         |       |
 | avif sequence | `.avifs`  | `image/avif-sequence` |     ✅     |         ✅         |       |
+
 
 ## Video
 
@@ -43,6 +46,7 @@ title: Supported Filetypes
 | ogv       | `.ogv`    | `video/ogg`              |     ✅     |         ✅         |       |
 | realvideo | `.rm`     | `video/vnd.rn-realvideo` |     ✅     |         ✅         |       |
 | wmv       | `.wmv`    | `video/x-ms-wmv`         |     ✅     |         ✅         |       |
+
 
 ## Audio
 
@@ -60,6 +64,7 @@ title: Supported Filetypes
 | wavpack        | `.wv`     | `audio/wavpack`          |         ✅         |       |
 | wma            | `.wma`    | `audio/x-ms-wma`         |         ✅         |       |
 
+
 ## Applications
 
 | Filetype | Extension | MIME type                       | Thumbnails | Viewable in Hydrus | Notes |
@@ -67,8 +72,8 @@ title: Supported Filetypes
 | flash    | `.swf`    | `application/x-shockwave-flash` |     ✅     |         ❌         |       |
 | pdf      | `.pdf`    | `application/pdf`               |     ❌     |         ❌         |       |
 
-## Image Project Files
 
+## Image Project Files
 
 | Filetype  | Extension    | MIME type                     | Thumbnails | Viewable in Hydrus | Notes             |
 | --------- | ------------ | ----------------------------- | :--------: | :----------------: | ----------------- |
@@ -79,6 +84,7 @@ title: Supported Filetypes
 | svg       | `.svg`       | `image/svg+xml`               |     ✅     |         ❌         |                   |
 | xcf       | `.xcf`       | `application/x-xcf`           |     ❌     |         ❌         | GIMP              |
 | procreate | `.procreate` | `application/x-procreate`[^1] |     ✅     |         ❌         | Procreate app     |
+
 
 ## Archives
 

--- a/docs/filetypes.md
+++ b/docs/filetypes.md
@@ -37,7 +37,7 @@ title: Supported Filetypes
 | webm      | `.webm`   | `video/webm`             |     ✅     |         ✅         |       |
 | matroska  | `.mkv`    | `video/x-matroska`       |     ✅     |         ✅         |       |
 | avi       | `.avi`    | `video/x-msvideo`        |     ✅     |         ✅         |       |
-| flv       | `.flv`    | `video/x-flv`            |     ✅     |         ❌         |       |
+| flv       | `.flv`    | `video/x-flv`            |     ✅     |         ✅         |       |
 | quicktime | `.mov`    | `video/quicktime`        |     ✅     |         ✅         |       |
 | mpeg      | `.mpeg`   | `video/mpeg`             |     ✅     |         ✅         |       |
 | ogv       | `.ogv`    | `video/ogg`              |     ✅     |         ✅         |       |

--- a/docs/filetypes.md
+++ b/docs/filetypes.md
@@ -90,4 +90,4 @@ title: Supported Filetypes
 | zip      | `.zip`    | `application/zip`             |       |
 
 
-[^1]: This filetype doesn't have an official or defacto media type, the one listed was made up for Hydrus.
+[^1]: This filetype doesn't have an official or de facto media type, the one listed was made up for Hydrus.

--- a/docs/getting_started_files.md
+++ b/docs/getting_started_files.md
@@ -65,38 +65,11 @@ Now:
 *   Play with the system tags more if you like, and the sort-by dropdown. The collect-by dropdown is advanced, so wait until you understand _namespaces_ before expecting it to do anything.
 *   To close a page, middle-click its tab.
 
-### The client can currently import the following mimetypes:
 
-*   **image/bmp** (.bmp - converted to image/png on import)
-*   **image/gif** (.gif)
-*   **image/png** (.png)
-*   **image/apng** (.apng)
-*   **image/jpeg** (.jpg)
-*   **image/svg+xml** (.svg)
-*   **image/tiff** (.tiff)
-*   **image/webp** (.webp)
-*   **video/x-msvideo** (.avi)
-*   **video/x-flv** (.flv)
-*   **video/x-matroska** (.mkv)
-*   **video/quicktime** (.mov)
-*   **video/mp4** (.mp4)
-*   **video/mpeg** (.mpeg)
-*   **video/webm** (.webm)
-*   **video/x-ms-wmv** (.wmv)
-*   **audio/mp3** (.mp3)
-*   **audio/ogg** (.ogg)
-*   **audio/flac** (.flac)
-*   **audio/x-ms-wma** (.wma)
-*   **application/x-shockwave-flash** (.swf)
-*   **application/pdf** (.pdf)
-*   **application/x-photoshop** (.psd)
-*   **application/clip** (.clip)
-*   **application/x-krita** (.kra, .krz)
-*   **application/sai2** (.sai2)
-*   **application/vnd.rar** (.rar)
-*   **application/zip** (.zip)
-*   **application/x-7z-compressed** (.7z)
-*   **application/gzip** (.gz)
+
+### Filetype support
+
+Hydrus supports many filetypes. A full list can be viewed on the [Supported Filetypes](filetypes.md) page.
 
 Although some support is imperfect for the complicated filetypes. For the Windows and Linux built releases, hydrus now embeds an MPV player for video, audio and gifs, which provides smooth playback and audio, but some other environments may not support MPV and so will default when possible to the native hydrus software renderer, which does not support audio. When something does not render how you want, right-clicking on its thumbnail presents the option 'open externally', which will open the file in the appropriate default program (e.g. ACDSee, VLC).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,12 +11,7 @@ The hydrus network client is a desktop application written for Anonymous and oth
 
 The software is constantly being improved. I try to put out a new release every Wednesday by 8pm Eastern.
 
-Currently importable filetypes are:
-
-*   images - jpg, gif (including animated), png (including animated!), tiff, webp, bmp
-*   video - webm, mp4, mpeg, avi, mov, mkv, flv, wmv
-*   audio - mp3, flac, ogg, wma
-*   misc - swf, pdf, psd, clip, sai2, zip, rar, 7z
+Hydrus supports various filetypes for images, video and audio files, image project files, and more. A full list of supported filetypes is [here](filetypes.md).
 
 On the Windows and Linux builds, an MPV window is embedded to play video and audio smoothly. For files like pdf, which cannot currently be viewed in the client, it is easy to launch any file with your OS's default program.
 

--- a/docs/running_from_source.md
+++ b/docs/running_from_source.md
@@ -29,7 +29,7 @@ There are now setup scripts that make this easy on Windows and Linux. You do not
 
 === "Linux"
 
-    You should already have a fairly new python. Ideally, you want at last 3.9.
+    You should already have a fairly new python. Ideally, you want at least 3.9.
 
 === "macOS"
 

--- a/mkdocs-gh-pages.yml
+++ b/mkdocs-gh-pages.yml
@@ -4,6 +4,7 @@ site_url: https://hydrusnetwork.github.io/hydrus/
 
 plugins:
   - search
+  - git-revision-date-localized
   - redirects:
       redirect_maps:
         'help/access_keys.md': 'access_keys.md'
@@ -47,3 +48,15 @@ plugins:
         'help/server.md': 'server.md'
         'help/support.md': 'support.md'
         'help/wine.md': 'wine.md'
+
+theme:
+  features:
+    - navigation.tracking
+    - navigation.sections
+    - navigation.tabs
+    - content.tabs.link
+    - navigation.top
+    - search.suggest
+    - content.code.annotate
+    - navigation.instant
+    - content.action.edit

--- a/mkdocs-gh-pages.yml
+++ b/mkdocs-gh-pages.yml
@@ -4,7 +4,9 @@ site_url: https://hydrusnetwork.github.io/hydrus/
 
 plugins:
   - search
-  - git-revision-date-localized
+  - git-revision-date-localized:
+      exclude:
+          - index.md
   - redirects:
       redirect_maps:
         'help/access_keys.md': 'access_keys.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - gettingStartedOverview.md
     - getting_started_installing.md
     - getting_started_files.md
+    - filetypes.md
     - getting_started_importing.md
     - getting_started_tags.md
     - getting_started_searching.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,8 +90,8 @@ theme:
   logo: assets/hydrus-white.svg
   favicon: assets/favicon.svg
   font: false
+  language: en
   features:
-    - navigation.instant
     - navigation.tracking
     - navigation.sections
     - navigation.tabs
@@ -158,3 +158,7 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tilde
   - pymdownx.snippets
+
+plugins:
+  - search
+  - offline


### PR DESCRIPTION
This PR updates the docs with a new page listing all the supported filetypes in one place and with details like extension, MIME, and whether they have thumbnails and if they can be displayed in the client. It also makes it so the local help has search and fixes some other issues.