### PR TITLE
Fix colors for PSDs

### DIFF
--- a/hydrus/core/HydrusPSDHandling.py
+++ b/hydrus/core/HydrusPSDHandling.py
@@ -44,11 +44,10 @@ def GenerateThumbnailNumPyFromPSDPath( path: str, target_resolution: typing.Tupl
     if clip_rect is not None:
         
         pil_image = HydrusImageHandling.ClipPILImage( pil_image, clip_rect )
-        
-    
-    thumbnail_pil_image = pil_image.resize( target_resolution, PILImage.LANCZOS )
 
-    thumbnail_pil_image = HydrusImageHandling.DequantizePILImage( thumbnail_pil_image )
+    pil_image = HydrusImageHandling.DequantizePILImage( pil_image )
+        
+    thumbnail_pil_image = pil_image.resize( target_resolution, PILImage.LANCZOS )
     
     numpy_image = HydrusImageHandling.GenerateNumPyImageFromPILImage(thumbnail_pil_image)
     

--- a/hydrus/core/HydrusPSDHandling.py
+++ b/hydrus/core/HydrusPSDHandling.py
@@ -47,10 +47,10 @@ def GenerateThumbnailNumPyFromPSDPath( path: str, target_resolution: typing.Tupl
         
     
     thumbnail_pil_image = pil_image.resize( target_resolution, PILImage.LANCZOS )
+
+    thumbnail_pil_image = HydrusImageHandling.DequantizePILImage( thumbnail_pil_image )
     
     numpy_image = HydrusImageHandling.GenerateNumPyImageFromPILImage(thumbnail_pil_image)
-    
-    numpy_image = HydrusImageHandling.DequantizeNumPyImage( numpy_image )
     
     return numpy_image
     


### PR DESCRIPTION
Closes #1448 

`HydrusImageHandling.DequantizeNumPyImage` should only be applied to images that are BGR (eg those directly from opencv). PIL produces RGB images already so this was inverting the colors on PSD thumbnails. Instead we use `HydrusImageHandling.DequantizePILImage` to handle edge cases. Also, it is important that this is done _before_ resizing.

Apparently the addition of `HydrusImageHandling.DequantizeNumPyImage` was to handle "greyspace" PSDs but I have tested greyscale PSDs without it on previous versions and it handles them fine so idk what was even happening. Adding `HydrusImageHandling.DequantizePILImage` seems to give nicer results for 32 bit and other odd image formats though. In v544 lab and indexed images would produce no thumbnail, this fixes that as well.