### PR TITLE
Added abort button on local import and url downloader pages

### DIFF
--- a/hydrus/client/gui/pages/ClientGUIManagementPanels.py
+++ b/hydrus/client/gui/pages/ClientGUIManagementPanels.py
@@ -57,6 +57,7 @@ from hydrus.client.gui.widgets import ClientGUIControls
 from hydrus.client.gui.widgets import ClientGUIMenuButton
 from hydrus.client.importing import ClientImporting
 from hydrus.client.importing import ClientImportWatchers
+from hydrus.client.importing import ClientImportLocal
 from hydrus.client.importing.options import FileImportOptions
 from hydrus.client.importing.options import PresentationImportOptions
 from hydrus.client.media import ClientMedia
@@ -1170,8 +1171,12 @@ class ManagementPanelImporterHDD( ManagementPanelImporter ):
         
         self._pause_button = ClientGUICommon.BetterBitmapButton( self._import_queue_panel, CC.global_pixmaps().file_pause, self.Pause )
         self._pause_button.setToolTip( 'pause/play imports' )
+
+        self._abort_button = ClientGUICommon.BetterBitmapButton( self._import_queue_panel, CC.global_pixmaps().stop, self.Abort )
+        self._abort_button.setToolTip( 'abort imports' )
         
-        self._hdd_import = self._management_controller.GetVariable( 'hdd_import' )
+
+        self._hdd_import: ClientImportLocal.HDDImport = self._management_controller.GetVariable( 'hdd_import' )
         
         file_import_options = self._hdd_import.GetFileImportOptions()
         
@@ -1192,6 +1197,7 @@ class ManagementPanelImporterHDD( ManagementPanelImporter ):
         hbox = QP.HBoxLayout()
         
         QP.AddToLayout( hbox, self._current_action, CC.FLAGS_CENTER_PERPENDICULAR_EXPAND_DEPTH )
+        QP.AddToLayout( hbox, self._abort_button, CC.FLAGS_CENTER_PERPENDICULAR )
         QP.AddToLayout( hbox, self._pause_button, CC.FLAGS_CENTER_PERPENDICULAR )
         
         self._import_queue_panel.Add( hbox, CC.FLAGS_EXPAND_SIZER_PERPENDICULAR )
@@ -1237,7 +1243,11 @@ class ManagementPanelImporterHDD( ManagementPanelImporter ):
             
             raise HydrusExceptions.VetoException( 'This page is still importing.' )
             
+    def Abort( self ):
         
+        self._hdd_import.AbortImport()
+        
+        self._UpdateImportStatus()
     
     def Pause( self ):
         

--- a/hydrus/client/gui/pages/ClientGUIManagementPanels.py
+++ b/hydrus/client/gui/pages/ClientGUIManagementPanels.py
@@ -58,6 +58,7 @@ from hydrus.client.gui.widgets import ClientGUIMenuButton
 from hydrus.client.importing import ClientImporting
 from hydrus.client.importing import ClientImportWatchers
 from hydrus.client.importing import ClientImportLocal
+from hydrus.client.importing import ClientImportSimpleURLs
 from hydrus.client.importing.options import FileImportOptions
 from hydrus.client.importing.options import PresentationImportOptions
 from hydrus.client.media import ClientMedia
@@ -1197,8 +1198,8 @@ class ManagementPanelImporterHDD( ManagementPanelImporter ):
         hbox = QP.HBoxLayout()
         
         QP.AddToLayout( hbox, self._current_action, CC.FLAGS_CENTER_PERPENDICULAR_EXPAND_DEPTH )
-        QP.AddToLayout( hbox, self._abort_button, CC.FLAGS_CENTER_PERPENDICULAR )
         QP.AddToLayout( hbox, self._pause_button, CC.FLAGS_CENTER_PERPENDICULAR )
+        QP.AddToLayout( hbox, self._abort_button, CC.FLAGS_CENTER_PERPENDICULAR )
         
         self._import_queue_panel.Add( hbox, CC.FLAGS_EXPAND_SIZER_PERPENDICULAR )
         self._import_queue_panel.Add( self._file_seed_cache_control, CC.FLAGS_EXPAND_PERPENDICULAR )
@@ -3200,7 +3201,7 @@ class ManagementPanelImporterSimpleDownloader( ManagementPanelImporter ):
         
         ManagementPanelImporter.__init__( self, parent, page, controller, management_controller )
         
-        self._simple_downloader_import = self._management_controller.GetVariable( 'simple_downloader_import' )
+        self._simple_downloader_import: ClientImportSimpleURLs.SimpleDownloaderImport = self._management_controller.GetVariable( 'simple_downloader_import' )
         
         #
         
@@ -3212,7 +3213,6 @@ class ManagementPanelImporterSimpleDownloader( ManagementPanelImporter ):
         
         self._pause_files_button = ClientGUICommon.BetterBitmapButton( self._import_queue_panel, CC.global_pixmaps().file_pause, self.PauseFiles )
         self._pause_files_button.setToolTip( 'pause/play files' )
-        
         self._current_action = ClientGUICommon.BetterStaticText( self._import_queue_panel, ellipsize_end = True )
         self._file_seed_cache_control = ClientGUIFileSeedCache.FileSeedCacheStatusControl( self._import_queue_panel, self._controller, self._page_key )
         self._file_download_control = ClientGUINetworkJobControl.NetworkJobControl( self._import_queue_panel )
@@ -3675,10 +3675,13 @@ class ManagementPanelImporterURLs( ManagementPanelImporter ):
         
         self._pause_button = ClientGUICommon.BetterBitmapButton( self._import_queue_panel, CC.global_pixmaps().file_pause, self.Pause )
         self._pause_button.setToolTip( 'pause/play files' )
+
+        self._abort_button = ClientGUICommon.BetterBitmapButton( self._import_queue_panel, CC.global_pixmaps().stop, self.Abort)
+        self._abort_button.setToolTip( 'abort files' )
         
         self._file_download_control = ClientGUINetworkJobControl.NetworkJobControl( self._import_queue_panel )
         
-        self._urls_import = self._management_controller.GetVariable( 'urls_import' )
+        self._urls_import: ClientImportSimpleURLs.URLsImport = self._management_controller.GetVariable( 'urls_import' )
         
         self._file_seed_cache_control = ClientGUIFileSeedCache.FileSeedCacheStatusControl( self._import_queue_panel, self._controller, page_key = self._page_key )
         
@@ -3710,8 +3713,12 @@ class ManagementPanelImporterURLs( ManagementPanelImporter ):
         self._import_options_button.SetNoteImportOptions( note_import_options )
         
         #
+        hbox = QP.HBoxLayout()
         
-        self._import_queue_panel.Add( self._pause_button, CC.FLAGS_ON_RIGHT )
+        QP.AddToLayout( hbox, self._pause_button, CC.FLAGS_ON_RIGHT )
+        QP.AddToLayout( hbox, self._abort_button, CC.FLAGS_ON_RIGHT )
+
+        self._import_queue_panel.Add( hbox, CC.FLAGS_ON_RIGHT )
         self._import_queue_panel.Add( self._file_seed_cache_control, CC.FLAGS_EXPAND_PERPENDICULAR )
         self._import_queue_panel.Add( self._file_download_control, CC.FLAGS_EXPAND_PERPENDICULAR )
         
@@ -3813,6 +3820,11 @@ class ManagementPanelImporterURLs( ManagementPanelImporter ):
             raise HydrusExceptions.VetoException( 'This page is still importing.' )
             
         
+    def Abort( self ):
+        
+        self._urls_import.AbortImport()
+        
+        self._UpdateImportStatus()
     
     def Pause( self ):
         

--- a/hydrus/client/importing/ClientImportLocal.py
+++ b/hydrus/client/importing/ClientImportLocal.py
@@ -173,6 +173,12 @@ class HDDImport( HydrusSerialisable.SerialisableBase ):
             return ( 3, new_serialisable_info )
             
         
+    def _EmptyFileSeedCache( self, status=CC.STATUS_UNKNOWN ):
+
+        self._file_seed_cache.RemoveFileSeeds( self._file_seed_cache.GetFileSeeds( status ) )
+            
+        time.sleep( ClientImporting.DID_SUBSTANTIAL_FILE_WORK_MINIMUM_SLEEP_TIME )
+            
     
     def _WorkOnFiles( self ):
         
@@ -365,6 +371,21 @@ class HDDImport( HydrusSerialisable.SerialisableBase ):
             ClientImporting.WakeRepeatingJob( self._files_repeating_job )
             
             self._SerialisableChangeMade()
+            
+    def AbortImport( self ):
+        
+        if self.CurrentlyWorking():
+            
+            self.PausePlay()
+            
+        self._EmptyFileSeedCache( CC.STATUS_UNKNOWN )
+        
+        self._paused = False
+
+        with self._lock:
+            
+            self._files_status = 'aborted'
+
             
         
     

--- a/hydrus/client/importing/ClientImportLocal.py
+++ b/hydrus/client/importing/ClientImportLocal.py
@@ -173,9 +173,9 @@ class HDDImport( HydrusSerialisable.SerialisableBase ):
             return ( 3, new_serialisable_info )
             
         
-    def _EmptyFileSeedCache( self, status=CC.STATUS_UNKNOWN ):
+    def _EmptyFileSeedCache( self, status: typing.Collection[int] = (CC.STATUS_UNKNOWN,) ):
 
-        self._file_seed_cache.RemoveFileSeeds( self._file_seed_cache.GetFileSeeds( status ) )
+        self._file_seed_cache.RemoveFileSeedsByStatus( status )
             
         time.sleep( ClientImporting.DID_SUBSTANTIAL_FILE_WORK_MINIMUM_SLEEP_TIME )
             
@@ -378,7 +378,7 @@ class HDDImport( HydrusSerialisable.SerialisableBase ):
             
             self.PausePlay()
             
-        self._EmptyFileSeedCache( CC.STATUS_UNKNOWN )
+        self._EmptyFileSeedCache()
         
         self._paused = False
 

--- a/hydrus/client/importing/ClientImportSimpleURLs.py
+++ b/hydrus/client/importing/ClientImportSimpleURLs.py
@@ -1007,6 +1007,11 @@ class URLsImport( HydrusSerialisable.SerialisableBase ):
             return ( 4, new_serialisable_info )
             
         
+    def _EmptyFileSeedCache( self, status=CC.STATUS_UNKNOWN ):
+
+        self._file_seed_cache.RemoveFileSeeds( self._file_seed_cache.GetFileSeeds( status ) )
+            
+        time.sleep( ClientImporting.DID_SUBSTANTIAL_FILE_WORK_MINIMUM_SLEEP_TIME )
     
     def _WorkOnFiles( self ):
         
@@ -1241,6 +1246,20 @@ class URLsImport( HydrusSerialisable.SerialisableBase ):
             
             self._SerialisableChangeMade()
             
+
+    def AbortImport( self ):
+        
+        if self.CurrentlyWorking():
+            
+            self.PausePlay()
+            
+        self._EmptyFileSeedCache( CC.STATUS_UNKNOWN )
+        
+        self._paused = False
+
+        with self._lock:
+            
+            self._files_status = 'aborted'
         
     
     def PendURLs( self, urls, filterable_tags = None, additional_service_keys_to_tags = None ):

--- a/hydrus/client/importing/ClientImportSimpleURLs.py
+++ b/hydrus/client/importing/ClientImportSimpleURLs.py
@@ -1,5 +1,6 @@
 import threading
 import time
+import typing
 import urllib.parse
 
 from hydrus.core import HydrusConstants as HC
@@ -1007,9 +1008,9 @@ class URLsImport( HydrusSerialisable.SerialisableBase ):
             return ( 4, new_serialisable_info )
             
         
-    def _EmptyFileSeedCache( self, status=CC.STATUS_UNKNOWN ):
+    def _EmptyFileSeedCache( self, status: typing.Collection[int] = (CC.STATUS_UNKNOWN,) ):
 
-        self._file_seed_cache.RemoveFileSeeds( self._file_seed_cache.GetFileSeeds( status ) )
+        self._file_seed_cache.RemoveFileSeedsByStatus( status )
             
         time.sleep( ClientImporting.DID_SUBSTANTIAL_FILE_WORK_MINIMUM_SLEEP_TIME )
     
@@ -1253,7 +1254,7 @@ class URLsImport( HydrusSerialisable.SerialisableBase ):
             
             self.PausePlay()
             
-        self._EmptyFileSeedCache( CC.STATUS_UNKNOWN )
+        self._EmptyFileSeedCache()
         
         self._paused = False
 


### PR DESCRIPTION
This addresses #1404 and adds a button next to the pause/play button on the file import page and the url downloader page, which 'aborts' the import.

The button empties the cache of files with UNKNOWN status, which makes it jump to 100% complete and stops importing files. The button works on both pages with no apparent issues from my testing.

Something similar can probably be done to the simple downloader page, but since I have never used it, I am not familiar with what it can do and decided to just leave it alone.
