### PR TITLE
Add call to expanduser for ipfs nocopy path mapping

### DIFF
--- a/hydrus/client/gui/services/ClientGUIClientsideServices.py
+++ b/hydrus/client/gui/services/ClientGUIClientsideServices.py
@@ -1600,7 +1600,7 @@ class EditServiceIPFSSubPanel( ClientGUICommon.StaticBox ):
             
             portable_hydrus_path = HydrusPaths.ConvertAbsPathToPortablePath( hydrus_path )
             
-            portable_dict[ portable_hydrus_path ] = ipfs_path
+            portable_dict[ portable_hydrus_path ] = os.path.expanduser(ipfs_path)
             
         
         dictionary_part[ 'nocopy_abs_path_translations' ] = portable_dict


### PR DESCRIPTION
This fixes #1320.

Wraps the ipfs path in `os.path.expanduser` which will expand `~` and `~user` to the home directory. Visually in the service window it will still show the `~`, but next time it is opened the expanded path should be shown.