### PR TITLE
Fix KDE 6 file picker causing hydrus to close

### DIFF
--- a/hydrus/client/ClientController.py
+++ b/hydrus/client/ClientController.py
@@ -112,6 +112,8 @@ class App( QW.QApplication ):
         
         self.setQuitOnLastWindowClosed( False )
         
+        self.setQuitLockEnabled( False )
+        
         self.call_after_catcher = QP.CallAfterEventCatcher( self )
         
         self.pubsub_catcher = PubSubEventCatcher( self, self._pubsub )


### PR DESCRIPTION
This fixes an issue many users were encountering on KDE 6 where closing the file picker (by selecting a file or just canceling or closing) would cause hydrus itself to close. 

See https://github.com/strawberrymusicplayer/strawberry/issues/1401 and https://bugs.kde.org/show_bug.cgi?id=483439