### PR TITLE
Fix importing posts with multiple file urls

### DIFF
--- a/hydrus/client/importing/ClientImportFileSeeds.py
+++ b/hydrus/client/importing/ClientImportFileSeeds.py
@@ -1590,6 +1590,8 @@ class FileSeed( HydrusSerialisable.SerialisableBase ):
                                 
                                 duplicate_file_seed.file_seed_data = child_url
                                 
+                                duplicate_file_seed.Normalise()
+                                
                                 duplicate_file_seed.SetReferralURL( url_for_child_referral )
 
                                 duplicate_file_seed.AddRequestHeaders( self._request_headers )


### PR DESCRIPTION
This fixes a bug where posts that produced multiple file urls only download the first one. There are potentially other solutions to this bug but this the one I landed on.

The issue stems from the child url file seeds being duplicated so they keep the same `file_seed_data_for_comparison` which is now what's used to hash the file seed for comparison which means later on when they're deduplicated before being added to the file seed cache all but one child url is removed. This patch adds an additional `Normalise()` call to the new duplicated file seeds after the new url is set which sets `file_seed_data_for_comparison` correctly.