### PR TITLE
Don't use the display's color profile for sRGB normalization

### DIFF
--- a/hydrus/core/files/images/HydrusImageNormalisation.py
+++ b/hydrus/core/files/images/HydrusImageNormalisation.py
@@ -12,14 +12,7 @@ from hydrus.core import HydrusExceptions
 from hydrus.core.files.images import HydrusImageColours
 from hydrus.core.files.images import HydrusImageMetadata
 
-try:
-    
-    PIL_SRGB_PROFILE = PILImageCms.get_display_profile()
-    
-except:
-    
-    PIL_SRGB_PROFILE = PILImageCms.createProfile( 'sRGB' )
-    
+PIL_SRGB_PROFILE = PILImageCms.createProfile( 'sRGB' )
 
 def NormaliseNumPyImageToUInt8( numpy_image: numpy.array ):
     


### PR DESCRIPTION
I can't find the reason this was added in v555 but trying to use the display's color profile for all sRGB normalization is incorrect and leads to hydrus generating bitmaps and thumbnails with wrong colors. I'm not sure we should be trying to convert images to the display's color profile at all but if that is done it needs to be done right when its about to be displayed.