### PR TITLE
use x0vncserver from tigervnc instead of x11vnc for docker 

### DIFF
--- a/static/build_files/docker/client/Dockerfile
+++ b/static/build_files/docker/client/Dockerfile
@@ -7,7 +7,7 @@ HEALTHCHECK --interval=20s --timeout=10s --retries=3 --start-period=30s CMD ! su
 ENTRYPOINT ["/bin/sh", "/opt/hydrus/static/build_files/docker/client/entrypoint.sh"]
 LABEL git="https://github.com/hydrusnetwork/hydrus"
 
-RUN apk --no-cache add fvwm x11vnc xvfb supervisor opencv mpv mpv-libs ffmpeg jq libheif \
+RUN apk --no-cache add fvwm xvfb tigervnc supervisor opencv mpv mpv-libs ffmpeg jq libheif \
  openssl nodejs patch font-noto font-noto-emoji font-noto-cjk \
  py3-pyside6 py3-beautifulsoup4 py3-pillow py3-numpy py3-openssl py3-cryptography py3-pip py3-opencv py3-lxml py3-chardet \
  py3-psutil py3-pysocks py3-requests py3-twisted py3-yaml py3-lz4 py3-html5lib py3-dateutil py3-qtpy py3-mpv py3-service_identity

--- a/static/build_files/docker/client/supervisord.conf
+++ b/static/build_files/docker/client/supervisord.conf
@@ -12,6 +12,7 @@ serverurl=unix:///run/supervisor.sock
 
 [supervisord]
 nodaemon=true
+
 [program:xvfb]
 command=Xvfb :89 -ac -listen tcp -screen 0 %(ENV_XVFBRES)s %(ENV_XVFB_EXTRA)s
 startretries=89
@@ -25,7 +26,7 @@ autostart=true
 autorestart=true
 
 [program:vnc]
-command=x11vnc -display :89 -forever -noxrecord -noxfixes -noxdamage -rfbport %(ENV_VNC_PORT)s %(ENV_VNC_EXTRA)s
+command=x0vncserver -display :89 -rfbport %(ENV_VNC_PORT)s -SecurityTypes=None %(ENV_VNC_EXTRA)s
 startretries=89
 autostart=true
 autorestart=true


### PR DESCRIPTION
x11vnc, the server used in the official docker build, currently has a bug which is preventing the clipboard from working properly. x11vnc has been unmaintained since January 2022, so this will most likely never be patched. x0vncserver is a drop-in replacement from TigerVNC, which is actively maintained. 

The only (minor) breaking change here is the password. With x11vnc, password is disabled by default and passing the parameter **-rfbauth** _passwd_file_ in the VNC_EXTRA environment variable enables it. With x0vncserver, security is on by default. For users who do not have a password set in VNC_EXTRA, there will be no difference, but for users who set a password in VNC_EXTRA, they will need to also add the `SecurityTypes=VncAuth` option like so: `VNC_EXTRA=-SecurityTypes=VncAuth -rfbauth /opt/hydrus/db/vncpasswd` to be prompted for a password.