### PR TITLE
Update macOS version choices in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -38,11 +38,12 @@ body:
           - Windows 11
           - Windows 10
           - Windows other (specify in comments)
-          - macOS 12 "Monterey" (Apple silicon)
-          - macOS 12 "Monterey" (Intel)
-          - macOS 11 "Big Sur" (Apple silicon)
-          - macOS 11 "Big Sur" (Intel)
-          - macOS 10.15 "Catalina"
+          - macOS 15 "Sequoia" (Apple silicon)
+          - macOS 15 "Sequoia" (Intel)
+          - macOS 14 "Sonoma" (Apple silicon)
+          - macOS 14 "Sonoma" (Intel)
+          - macOS 13 "Ventura" (Apple silicon)
+          - macOS 13 "Ventura" (Intel)
           - macOS other (specify in comments)
           - Linux (specify distro and version in comments)
           - Other (aka none of the above, specify in the comments)


### PR DESCRIPTION
We have not had a reported issue from macOS 11 or earlier in over a year. We have had recent reports from someone choosing the macOS 12 option, but in one of their issues (#1630), they admit to using a Macbook with an M3 chip, which released after macOS 13 was released. So, they probably just chose the most recent macOS version from the dropdown, rather than choosing "macOS other". Otherwise, it's all been 13 or higher for a long time.