### PR TITLE
Replace deprecated numpy functions (tostring and fromstring)

### DIFF
--- a/hydrus/client/ClientSerialisable.py
+++ b/hydrus/client/ClientSerialisable.py
@@ -149,7 +149,7 @@ def DumpToPNG( width, payload_bytes, title, payload_description, text, path ):
     
     header_and_payload_bytes = payload_length_header + payload_bytes + b'\x00' * num_empty_bytes
     
-    payload_image = numpy.fromstring( header_and_payload_bytes, dtype = 'uint8' ).reshape( ( payload_height, width ) )
+    payload_image = numpy.frombuffer( header_and_payload_bytes, dtype = 'uint8' ).reshape( ( payload_height, width ) )
     
     finished_image = numpy.concatenate( ( top_image, payload_image ) )
     

--- a/hydrus/client/gui/ClientGUIFunctions.py
+++ b/hydrus/client/gui/ClientGUIFunctions.py
@@ -152,7 +152,7 @@ def ConvertQtImageToNumPy( qt_image: QG.QImage, strip_useless_alpha = True ):
     
     if qt_image.bytesPerLine() == width * depth:
         
-        numpy_image = numpy.fromstring( data_bytes, dtype = 'uint8' ).reshape( ( height, width, depth ) )
+        numpy_image = numpy.frombuffer( data_bytes, dtype = 'uint8' ).reshape( ( height, width, depth ) )
         
     else:
         
@@ -165,7 +165,7 @@ def ConvertQtImageToNumPy( qt_image: QG.QImage, strip_useless_alpha = True ):
         desired_bytes_per_line = width * depth
         excess_bytes_to_trim = bytes_per_line - desired_bytes_per_line
         
-        numpy_padded = numpy.fromstring( data_bytes, dtype = 'uint8' ).reshape( ( height, bytes_per_line ) )
+        numpy_padded = numpy.frombuffer( data_bytes, dtype = 'uint8' ).reshape( ( height, bytes_per_line ) )
         
         numpy_image = numpy_padded[ :, : -excess_bytes_to_trim ].reshape( ( height, width, depth ) )
         

--- a/hydrus/core/files/HydrusVideoHandling.py
+++ b/hydrus/core/files/HydrusVideoHandling.py
@@ -1023,7 +1023,7 @@ class VideoRendererFFMPEG( object ):
                 
             else:
                 
-                result = numpy.fromstring( s, dtype = 'uint8' ).reshape( ( h, w, self.depth ) )
+                result = numpy.frombuffer( s, dtype = 'uint8' ).reshape( ( h, w, self.depth ) )
                 
                 self.lastread = result
                 

--- a/hydrus/core/files/images/HydrusImageHandling.py
+++ b/hydrus/core/files/images/HydrusImageHandling.py
@@ -451,7 +451,7 @@ def GenerateFileBytesNumPy( numpy_image, ext: str = '.png', params: typing.Optio
     if result_success:
         
         # noinspection PyUnresolvedReferences
-        return result_byte_array.tostring()
+        return result_byte_array.tobytes()
         
     else:
         


### PR DESCRIPTION
[np.tostring and binary mode of np.fromstring were removed from numpy 2.3.0](https://github.com/numpy/numpy/pull/28254), which broke the application on machines with that version of numpy installed. this pr replaces removed functions