### PR TITLE
Fix https://github.com/hydrusnetwork/hydrus/issues/1759

### DIFF
--- a/hydrus/client/ClientOptions.py
+++ b/hydrus/client/ClientOptions.py
@@ -522,13 +522,17 @@ class ClientOptions( HydrusSerialisable.SerialisableBase ):
         
         self._dictionary[ 'floats' ] = {
             'draw_thumbnail_rating_icon_size_px' : ClientGUIPainterShapes.SIZE.width(),
-            'thumbnail_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2,
+            'thumbnail_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2, #deprecated
+            'thumbnail_rating_incdec_height_px' : ClientGUIPainterShapes.SIZE.height(),
             'media_viewer_rating_icon_size_px' : ClientGUIPainterShapes.SIZE.width(),
-            'media_viewer_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2,
+            'media_viewer_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2, #deprecated
+            'media_viewer_rating_incdec_height_px' : ClientGUIPainterShapes.SIZE.height(),
             'preview_window_rating_icon_size_px' : ClientGUIPainterShapes.SIZE.width(),
-            'preview_window_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2,
+            'preview_window_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2, #deprecated
+            'preview_window_rating_incdec_height_px' : ClientGUIPainterShapes.SIZE.height(),
             'dialog_rating_icon_size_px' : ClientGUIPainterShapes.SIZE.width(),
-            'dialog_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2,
+            'dialog_rating_incdec_width_px' : ClientGUIPainterShapes.SIZE.width() * 2, #deprecated
+            'dialog_rating_incdec_height_px' : ClientGUIPainterShapes.SIZE.height(),
         }
         
         #

--- a/hydrus/client/db/ClientDB.py
+++ b/hydrus/client/db/ClientDB.py
@@ -8973,6 +8973,34 @@ class DB( HydrusDB.HydrusDB ):
                 self.pub_initial_message( message )
                 
             
+            if version == 633:
+                
+                try:
+                    
+                    new_options = self.modules_serialisable.GetJSONDump( HydrusSerialisable.SERIALISABLE_TYPE_CLIENT_OPTIONS )
+                    
+                    thumbnail_rating_incdec_width_px = new_options.GetFloat( 'thumbnail_rating_incdec_width_px' )
+                    media_viewer_rating_incdec_width_px = new_options.GetFloat( 'media_viewer_rating_incdec_width_px' )
+                    preview_window_rating_incdec_width_px = new_options.GetFloat( 'preview_window_rating_incdec_width_px' )
+                    dialog_rating_incdec_width_px = new_options.GetFloat( 'dialog_rating_incdec_width_px' )
+                    
+                    new_options.SetFloat( 'thumbnail_rating_incdec_height_px', thumbnail_rating_incdec_width_px / 2 )
+                    new_options.SetFloat( 'media_viewer_rating_incdec_height_px', media_viewer_rating_incdec_width_px / 2 )
+                    new_options.SetFloat( 'preview_window_rating_incdec_height_px', preview_window_rating_incdec_width_px / 2 )
+                    new_options.SetFloat( 'dialog_rating_incdec_height_px', dialog_rating_incdec_width_px / 2 )
+                    
+                    self.modules_serialisable.SetJSONDump( new_options )
+                    
+                except Exception as e:
+                    
+                    HydrusData.PrintException( e )
+                    
+                    message = 'Trying to update your \'rating_incdec_height_px\' options failed! Please let hydrus dev know!'
+                    
+                    self.pub_initial_message( message )
+                    
+                
+            
         
         self._controller.frame_splash_status.SetTitleText( 'updated db to v{}'.format( HydrusNumbers.ToHumanInt( version + 1 ) ) )
         

--- a/hydrus/client/gui/ClientGUIRatings.py
+++ b/hydrus/client/gui/ClientGUIRatings.py
@@ -275,32 +275,44 @@ def GetIconSize( canvas_type, service_type = ClientGUICommon.HC.LOCAL_RATING_LIK
     if canvas_type in CC.CANVAS_MEDIA_VIEWER_TYPES:
         
         rating_icon_size_px = CG.client_controller.new_options.GetFloat( 'media_viewer_rating_icon_size_px' )
-        rating_incdec_width_px = CG.client_controller.new_options.GetFloat( 'media_viewer_rating_incdec_width_px' )
+        rating_incdec_height_px = CG.client_controller.new_options.GetFloat( 'media_viewer_rating_incdec_height_px' )
         
     elif canvas_type == CC.CANVAS_PREVIEW:
         
         rating_icon_size_px = CG.client_controller.new_options.GetFloat( 'preview_window_rating_icon_size_px' )
-        rating_incdec_width_px = CG.client_controller.new_options.GetFloat( 'preview_window_rating_incdec_width_px' )
+        rating_incdec_height_px = CG.client_controller.new_options.GetFloat( 'preview_window_rating_incdec_height_px' )
         
     elif canvas_type == CC.CANVAS_DIALOG:
         
         rating_icon_size_px = CG.client_controller.new_options.GetFloat( 'dialog_rating_icon_size_px' )
-        rating_incdec_width_px = CG.client_controller.new_options.GetFloat( 'dialog_rating_incdec_width_px' )
+        rating_incdec_height_px = CG.client_controller.new_options.GetFloat( 'dialog_rating_incdec_height_px' )
         
     else:
         
         rating_icon_size_px = CG.client_controller.new_options.GetFloat( 'draw_thumbnail_rating_icon_size_px' )
-        rating_incdec_width_px = CG.client_controller.new_options.GetFloat( 'thumbnail_rating_incdec_width_px' )
+        rating_incdec_height_px = CG.client_controller.new_options.GetFloat( 'thumbnail_rating_incdec_height_px' )
         
     
     if service_type == ClientGUICommon.HC.LOCAL_RATING_INCDEC:
         
-        return QC.QSize( round( rating_incdec_width_px ), round( rating_incdec_width_px / 2 ) )
+        return QC.QSize( rating_incdec_height_px * 2, rating_incdec_height_px )
         
     else:
         
         return QC.QSize( round( rating_icon_size_px ), round( rating_icon_size_px ) )
         
+    
+
+def GetIncDecSize( box_height, rating_number ) -> QC.QSize:
+    
+    box_width = box_height * 2
+    
+    if rating_number is not None and rating_number > 0 and len( str( rating_number ) ) > 3:
+        
+        box_width += ( box_height - 2 ) * ( len( str( rating_number ) ) - 3 )
+        
+    
+    return QC.QSize( box_width, box_height )
     
 
 def GetNumericalFractionText( rating_state, stars ):
@@ -570,6 +582,8 @@ class RatingIncDec( QW.QWidget ):
                     
                     dlg.SetPanel( panel )
                     
+                    control.setFocus()
+                    
                     if dlg.exec() == QW.QDialog.DialogCode.Accepted:
                         
                         new_rating = control.value()
@@ -617,7 +631,7 @@ class RatingIncDec( QW.QWidget ):
     
     def UpdateSize( self ):
         
-        self._icon_size = GetIconSize( self._canvas_type, ClientGUICommon.HC.LOCAL_RATING_INCDEC )
+        self._icon_size = GetIncDecSize( GetIconSize( self._canvas_type, ClientGUICommon.HC.LOCAL_RATING_INCDEC ).height(), self._rating )
         
         self.setMinimumSize( QC.QSize( self._icon_size.width(), self._icon_size.height() + STAR_PAD.height() ) )
         

--- a/hydrus/client/gui/ClientGUIRatings.py
+++ b/hydrus/client/gui/ClientGUIRatings.py
@@ -307,11 +307,18 @@ def GetIncDecSize( box_height, rating_number ) -> QC.QSize:
     
     box_width = box_height * 2
     
-    if rating_number is not None and rating_number > 0 and len( str( rating_number ) ) > 3:
+    if rating_number is not None and rating_number > 0:
         
-        box_width += ( box_height - 2 ) * ( len( str( rating_number ) ) - 3 )
+        digits = len( str( rating_number ) )
         
-    
+        if digits > 3:
+            
+            box_width += ( box_height - 1 ) * ( digits - ( 2 + ( digits / 3 ) ) ) 
+            #the below increases the padding drastically with more digits, the above has a constant pad
+            #more dramatic indent for bigger numbers seems sometimes better visually, but let's tend towards saving space
+            #box_width += ( box_height - 1 ) * ( digits - 3 )
+            
+        
     return QC.QSize( box_width, box_height )
     
 

--- a/hydrus/client/gui/canvas/ClientGUICanvas.py
+++ b/hydrus/client/gui/canvas/ClientGUICanvas.py
@@ -1950,7 +1950,7 @@ class CanvasPanelWithHovers( CanvasPanel ):
         # ratings
         
         RATING_ICON_SET_SIZE = round( self._new_options.GetFloat( 'preview_window_rating_icon_size_px' ) )
-        RATING_INCDEC_SET_WIDTH = round( self._new_options.GetFloat( 'preview_window_rating_incdec_width_px' ) )
+        RATING_INCDEC_SET_HEIGHT = round( self._new_options.GetFloat( 'preview_window_rating_incdec_height_px' ) )
         STAR_DX = RATING_ICON_SET_SIZE
         STAR_DY = RATING_ICON_SET_SIZE
         STAR_PAD = ClientGUIPainterShapes.PAD
@@ -1970,7 +1970,7 @@ class CanvasPanelWithHovers( CanvasPanel ):
             
             rating_state = ClientRatings.GetLikeStateFromMedia( ( self._current_media, ), service_key )
             
-            ClientGUIRatings.DrawLike( painter, like_rating_current_x, current_y, service_key, rating_state, QC.QSize( STAR_DX, STAR_DY ))
+            ClientGUIRatings.DrawLike( painter, like_rating_current_x, current_y, service_key, rating_state, QC.QSize( STAR_DX, STAR_DY ) )
             
             like_rating_current_x -= STAR_DX + STAR_PAD.width()
             
@@ -2005,9 +2005,9 @@ class CanvasPanelWithHovers( CanvasPanel ):
         
         incdec_services.reverse()
         
-        control_width = RATING_INCDEC_SET_WIDTH + 1
+        incdec_rating_current_x = my_width - ( QFRAME_PADDING + VBOX_MARGIN )
         
-        incdec_rating_current_x = my_width - ( control_width ) - ( QFRAME_PADDING + VBOX_MARGIN )
+        control_width = RATING_INCDEC_SET_HEIGHT * 2
         
         for incdec_service in incdec_services:
             
@@ -2015,14 +2015,20 @@ class CanvasPanelWithHovers( CanvasPanel ):
             
             ( rating_state, rating ) = ClientRatings.GetIncDecStateFromMedia( ( self._current_media, ), service_key )
             
-            ClientGUIRatings.DrawIncDec( painter, incdec_rating_current_x, current_y, service_key, rating_state, rating, QC.QSize( round( RATING_INCDEC_SET_WIDTH ), round( RATING_INCDEC_SET_WIDTH / 2 ) ) )
+            incdec_size = ClientGUIRatings.GetIncDecSize( RATING_INCDEC_SET_HEIGHT, rating )
             
-            incdec_rating_current_x -= control_width    #+ STAR_PAD.width() #instead of spacing these out, we will just have them pixel-adjacent in all cases
+            control_width = incdec_size.width() + 1
             
+            incdec_rating_current_x -= control_width
+            
+            ClientGUIRatings.DrawIncDec( painter, incdec_rating_current_x, current_y, service_key, rating_state, rating, incdec_size )
+            
+        
+        incdec_rating_current_x -= control_width
         
         if len( incdec_services ) > 0:
             
-            current_y += round( RATING_INCDEC_SET_WIDTH / 2 ) + round( STAR_PAD.height() / 2 ) + VBOX_SPACING
+            current_y += RATING_INCDEC_SET_HEIGHT + round( STAR_PAD.height() / 2 ) + VBOX_SPACING
             
         
         # icons
@@ -2542,7 +2548,7 @@ class CanvasWithHovers( Canvas ):
         # ratings
         
         RATING_ICON_SET_SIZE = round( self._new_options.GetFloat( 'media_viewer_rating_icon_size_px' ) )
-        RATING_INCDEC_SET_WIDTH = round( self._new_options.GetFloat( 'media_viewer_rating_incdec_width_px' ) )
+        RATING_INCDEC_SET_HEIGHT = round( self._new_options.GetFloat( 'media_viewer_rating_incdec_height_px' ) )
         STAR_DX = RATING_ICON_SET_SIZE
         STAR_DY = RATING_ICON_SET_SIZE
         STAR_PAD = ClientGUIPainterShapes.PAD
@@ -2597,9 +2603,9 @@ class CanvasWithHovers( Canvas ):
         
         incdec_services.reverse()
         
-        control_width = RATING_INCDEC_SET_WIDTH + 1
+        incdec_rating_current_x = my_width - ( QFRAME_PADDING + VBOX_MARGIN )
         
-        incdec_rating_current_x = my_width - ( control_width ) - ( QFRAME_PADDING + VBOX_MARGIN )
+        control_width = RATING_INCDEC_SET_HEIGHT * 2
         
         for incdec_service in incdec_services:
             
@@ -2607,14 +2613,20 @@ class CanvasWithHovers( Canvas ):
             
             ( rating_state, rating ) = ClientRatings.GetIncDecStateFromMedia( ( self._current_media, ), service_key )
             
-            ClientGUIRatings.DrawIncDec( painter, incdec_rating_current_x, current_y, service_key, rating_state, rating, QC.QSize( round( RATING_INCDEC_SET_WIDTH ), round( RATING_INCDEC_SET_WIDTH / 2 ) ) )
+            incdec_size = ClientGUIRatings.GetIncDecSize( RATING_INCDEC_SET_HEIGHT, rating )
             
-            incdec_rating_current_x -= control_width    #+ STAR_PAD.width() #instead of spacing these out, we will just have them pixel-adjacent in all cases
+            control_width = incdec_size.width() + 1
             
+            incdec_rating_current_x -= control_width
+            
+            ClientGUIRatings.DrawIncDec( painter, incdec_rating_current_x, current_y, service_key, rating_state, rating, incdec_size )
+            
+        
+        incdec_rating_current_x -= control_width
         
         if len( incdec_services ) > 0:
             
-            current_y += round( RATING_INCDEC_SET_WIDTH / 2 ) + round( STAR_PAD.height() / 2 ) + VBOX_SPACING
+            current_y += RATING_INCDEC_SET_HEIGHT + round( STAR_PAD.height() / 2 ) + VBOX_SPACING
             
         
         # icons

--- a/hydrus/client/gui/canvas/ClientGUICanvasHoverFrames.py
+++ b/hydrus/client/gui/canvas/ClientGUICanvasHoverFrames.py
@@ -60,6 +60,7 @@ class RatingIncDecCanvas( ClientGUIRatings.RatingIncDec ):
         self._hashes = set()
         
         CG.client_controller.sub( self, 'ProcessContentUpdatePackage', 'content_updates_gui' )
+        CG.client_controller.sub( self, 'NotifyNewOptions', 'notify_new_options' )
         
     
     def _Draw( self, painter ):
@@ -70,18 +71,11 @@ class RatingIncDecCanvas( ClientGUIRatings.RatingIncDec ):
         
         if self._current_media is not None:
             
-            icon_size = ClientGUIRatings.GetIconSize( self._canvas_type, HC.LOCAL_RATING_INCDEC )
+            self._iconsize =  ClientGUIRatings.GetIncDecSize( ClientGUIRatings.GetIconSize( self._canvas_type, HC.LOCAL_RATING_INCDEC ).height(), self._rating )
             
-            ClientGUIRatings.DrawIncDec( painter, self._iconpad.width(), self._iconpad.height(), self._service_key, self._rating_state, self._rating, icon_size )
+            ClientGUIRatings.DrawIncDec( painter, self._iconpad.width(), self._iconpad.height(), self._service_key, self._rating_state, self._rating, self._iconsize )
             
-            if self._iconsize != icon_size:
-                
-                self._iconsize = icon_size
-                self.UpdateSize()
-                
-                self._panel.hide()
-                self._panel.DoRegularHideShow()
-                
+            self.UpdateSize()
             
         
     
@@ -100,6 +94,13 @@ class RatingIncDecCanvas( ClientGUIRatings.RatingIncDec ):
     def ClearMedia( self ):
         
         self.SetMedia( None )
+        
+    
+    def NotifyNewOptions( self ):
+        
+        self._iconsize =  ClientGUIRatings.GetIncDecSize( ClientGUIRatings.GetIconSize( self._canvas_type, HC.LOCAL_RATING_INCDEC ).height(), self._rating )
+        
+        self._panel.DoRegularHideShow()
         
     
     def ProcessContentUpdatePackage( self, content_update_package: ClientContentUpdates.ContentUpdatePackage ):

--- a/hydrus/client/gui/panels/ClientGUIManageOptionsPanel.py
+++ b/hydrus/client/gui/panels/ClientGUIManageOptionsPanel.py
@@ -4624,9 +4624,9 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             media_viewer_rating_panel = ClientGUICommon.StaticBox( self, 'media viewer' )
             
             self._media_viewer_rating_icon_size_px = ClientGUICommon.BetterDoubleSpinBox( media_viewer_rating_panel, min = 1.0, max = 255.0 )
-            self._media_viewer_rating_icon_size_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set size in pixels for like, numerical, and inc/dec rating icons for clicking on. This will be used for both width and height of the square icons. If you want to set the size of ratings icons in thumbnails, check the \'thumbnails\' options page.' ) )
-            self._media_viewer_rating_incdec_width_px = ClientGUICommon.BetterDoubleSpinBox( media_viewer_rating_panel, min = 2.0, max = 255.0 )
-            self._media_viewer_rating_incdec_width_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set width in pixels for inc/dec rectangles in the media viewer. The height will be half of this, and it is limited to be between twice and half of the normal ratings icons sizes. If you want to set the size of ratings icons in thumbnails, check the \'thumbnails\' options page.' ) )
+            self._media_viewer_rating_icon_size_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set size in pixels for like, numerical, and inc/dec rating icons for clicking on. This will be used for both width and height of the square icons.' ) )
+            self._media_viewer_rating_incdec_height_px = ClientGUICommon.BetterDoubleSpinBox( media_viewer_rating_panel, min = 2.0, max = 255.0 )
+            self._media_viewer_rating_incdec_height_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set height in pixels for inc/dec rectangles in the media viewer. Width will be dynamic based on the rating. It is limited to be between twice and half of the normal ratings icons sizes.' ) )
             
             
             thumbnail_ratings_panel = ClientGUICommon.StaticBox( self, 'thumbnails' )
@@ -4638,12 +4638,12 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             self._draw_thumbnail_rating_background.setToolTip( ClientGUIFunctions.WrapToolTip( tt ) )
             
             self._draw_thumbnail_rating_icon_size_px = ClientGUICommon.BetterDoubleSpinBox( thumbnail_ratings_panel, min = 1.0, max = thumbnail_width )
-            tt = 'This is the size of any rating icons shown in pixels. It will be square, so this is both the width and height. This only sets it for display on thumbnails, if you want to change the size of icons in the media viewer check the \'media viewer\' options page.'
+            tt = 'This is the size of any rating icons shown in pixels. It will be square, so this is both the width and height.'
             self._draw_thumbnail_rating_icon_size_px.setToolTip( ClientGUIFunctions.WrapToolTip( tt ) )
             
-            self._draw_thumbnail_rating_incdec_width_px = ClientGUICommon.BetterDoubleSpinBox( thumbnail_ratings_panel, min = 2.0, max = thumbnail_width )
+            self._draw_thumbnail_rating_incdec_height_px = ClientGUICommon.BetterDoubleSpinBox( thumbnail_ratings_panel, min = 2.0, max = thumbnail_width )
             tt = 'This is the width of the inc/dec rating buttons in pixels. Height is 1/2 this. Limited to a range around the rating icon sizes.'
-            self._draw_thumbnail_rating_incdec_width_px.setToolTip( ClientGUIFunctions.WrapToolTip( tt ) )
+            self._draw_thumbnail_rating_incdec_height_px.setToolTip( ClientGUIFunctions.WrapToolTip( tt ) )
             
             self._draw_thumbnail_numerical_ratings_collapsed_always = QW.QCheckBox( thumbnail_ratings_panel )
             tt = 'If this is checked, all numerical ratings will show collapsed in thumbnails (\'2/10 ▲\' instead of \'▲▲▼▼▼▼▼▼▼▼\') regardless of the per-service setting.'
@@ -4655,8 +4655,8 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             self._preview_window_rating_icon_size_px = ClientGUICommon.BetterDoubleSpinBox( preview_window_rating_panel, min = 1.0, max = 255.0 )
             self._preview_window_rating_icon_size_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set size in pixels for like and numerical rating icons for clicking on in the preview window.' ) )
             
-            self._preview_window_rating_incdec_width_px  = ClientGUICommon.BetterDoubleSpinBox( preview_window_rating_panel, min = 2.0, max = 255.0 )
-            self._preview_window_rating_incdec_width_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set width in pixels for inc/dec rectangles in the preview window. The height will be half of this, and it is limited to be between twice and half of the normal ratings icons sizes.' ) )
+            self._preview_window_rating_incdec_height_px  = ClientGUICommon.BetterDoubleSpinBox( preview_window_rating_panel, min = 2.0, max = 255.0 )
+            self._preview_window_rating_incdec_height_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set height in pixels for inc/dec rectangles in the preview window. Width will be dynamic based on the rating. It is limited to be between twice and half of the normal ratings icons sizes.' ) )
             
             
             manage_ratings_popup_panel = ClientGUICommon.StaticBox( self, 'dialogs' )
@@ -4664,8 +4664,8 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             self._dialog_rating_icon_size_px = ClientGUICommon.BetterDoubleSpinBox( manage_ratings_popup_panel, min = 6.0, max = 128.0 )
             self._dialog_rating_icon_size_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set size in pixels for like and numerical rating icons for clicking on in the \'manage ratings\' dialog.' ) )
             
-            self._dialog_rating_incdec_width_px = ClientGUICommon.BetterDoubleSpinBox( manage_ratings_popup_panel, min = 12.0, max = 128.0 )
-            self._dialog_rating_incdec_width_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set width in pixels for inc/dec rectangles in the \'manage ratings\' dialog. The height will be half of this, and it is limited to be between twice and half of the normal ratings icons sizes.' ) )
+            self._dialog_rating_incdec_height_px = ClientGUICommon.BetterDoubleSpinBox( manage_ratings_popup_panel, min = 12.0, max = 128.0 )
+            self._dialog_rating_incdec_height_px.setToolTip( ClientGUIFunctions.WrapToolTip( 'Set height in pixels for inc/dec rectangles in the \'manage ratings\' dialog.  Width will be dynamic based on the rating. It is limited to be between twice and half of the normal ratings icons sizes.' ) )
             
             #clamp inc/dec rectangles to min 0.5 and max 2x rating stars px for rating size stuff
             self._media_viewer_rating_icon_size_px.editingFinished.connect( self._icon_size_changed )
@@ -4675,25 +4675,25 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             #
             
             self._media_viewer_rating_icon_size_px.setValue( self._new_options.GetFloat( 'media_viewer_rating_icon_size_px' ) )
-            self._media_viewer_rating_incdec_width_px.setValue( self._new_options.GetFloat( 'media_viewer_rating_incdec_width_px' ) )
+            self._media_viewer_rating_incdec_height_px.setValue( self._new_options.GetFloat( 'media_viewer_rating_incdec_height_px' ) )
             
             self._draw_thumbnail_rating_background.setChecked( self._new_options.GetBoolean( 'draw_thumbnail_rating_background' ) )
             self._draw_thumbnail_numerical_ratings_collapsed_always.setChecked( self._new_options.GetBoolean( 'draw_thumbnail_numerical_ratings_collapsed_always' ) )
             self._draw_thumbnail_rating_icon_size_px.setValue( self._new_options.GetFloat( 'draw_thumbnail_rating_icon_size_px' ) )
-            self._draw_thumbnail_rating_incdec_width_px.setValue( self._new_options.GetFloat( 'thumbnail_rating_incdec_width_px' )  )
+            self._draw_thumbnail_rating_incdec_height_px.setValue( self._new_options.GetFloat( 'thumbnail_rating_incdec_height_px' )  )
             
             self._preview_window_rating_icon_size_px.setValue( self._new_options.GetFloat( 'preview_window_rating_icon_size_px' ) )
-            self._preview_window_rating_incdec_width_px.setValue( self._new_options.GetFloat( 'preview_window_rating_incdec_width_px' ) )
+            self._preview_window_rating_incdec_height_px.setValue( self._new_options.GetFloat( 'preview_window_rating_incdec_height_px' ) )
             
             self._dialog_rating_icon_size_px.setValue( self._new_options.GetFloat( 'dialog_rating_icon_size_px' ) )
-            self._dialog_rating_incdec_width_px.setValue( self._new_options.GetFloat( 'dialog_rating_incdec_width_px' ) )
+            self._dialog_rating_incdec_height_px.setValue( self._new_options.GetFloat( 'dialog_rating_incdec_height_px' ) )
             
             #
             
             rows = []
             
             rows.append( ( 'Media viewer like/dislike and numerical rating icon size:', self._media_viewer_rating_icon_size_px ) )
-            rows.append( ( 'Media viewer inc/dec rating icon width:', self._media_viewer_rating_incdec_width_px ) )
+            rows.append( ( 'Media viewer inc/dec rating icon height:', self._media_viewer_rating_incdec_height_px ) )
             
             media_viewer_rating_gridbox = ClientGUICommon.WrapInGrid( media_viewer_rating_panel, rows )
             media_viewer_rating_panel.Add( media_viewer_rating_gridbox, CC.FLAGS_EXPAND_SIZER_PERPENDICULAR )
@@ -4701,7 +4701,7 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             rows = []
             
             rows.append( ( 'Preview window like/dislike and numerical rating icon size:', self._preview_window_rating_icon_size_px ) )
-            rows.append( ( 'Preview window inc/dec rating icon width:', self._preview_window_rating_incdec_width_px ) )
+            rows.append( ( 'Preview window inc/dec rating icon height:', self._preview_window_rating_incdec_height_px ) )
             
             preview_hovers_gridbox = ClientGUICommon.WrapInGrid( preview_window_rating_panel, rows )
             preview_window_rating_panel.Add( preview_hovers_gridbox, CC.FLAGS_EXPAND_SIZER_PERPENDICULAR )
@@ -4709,7 +4709,7 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             rows = []
             
             rows.append( ( 'Thumbnail like/dislike and numerical rating icon size: ', self._draw_thumbnail_rating_icon_size_px ) )
-            rows.append( ( 'Thumbnail inc/dec rating width: ', self._draw_thumbnail_rating_incdec_width_px ) )
+            rows.append( ( 'Thumbnail inc/dec rating height: ', self._draw_thumbnail_rating_incdec_height_px ) )
             rows.append( ( 'Give thumbnail ratings a flat background: ', self._draw_thumbnail_rating_background ) )
             rows.append( ( 'Always draw thumbnail numerical ratings collapsed: ', self._draw_thumbnail_numerical_ratings_collapsed_always ) )
             
@@ -4719,7 +4719,7 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             rows = []
             
             rows.append( ( 'Dialogs like/dislike and numerical rating icon size:', self._dialog_rating_icon_size_px ) )
-            rows.append( ( 'Dialogs inc/dec rating width:', self._dialog_rating_incdec_width_px ) )
+            rows.append( ( 'Dialogs inc/dec rating height:', self._dialog_rating_incdec_height_px ) )
             
             manage_ratings_gridbox = ClientGUICommon.WrapInGrid( manage_ratings_popup_panel, rows )
             
@@ -4751,35 +4751,35 @@ class ManageOptionsPanel( ClientGUIScrolledPanels.ManagePanel ):
             
             new_value = self._media_viewer_rating_icon_size_px.value()
             
-            self._media_viewer_rating_incdec_width_px.setMaximum( new_value * 2 )
-            self._media_viewer_rating_incdec_width_px.setMinimum( new_value * 0.5 )
+            self._media_viewer_rating_incdec_height_px.setMaximum( new_value * 2 )
+            self._media_viewer_rating_incdec_height_px.setMinimum( new_value * 0.5 )
             
             new_value = self._preview_window_rating_icon_size_px.value()
             
-            self._preview_window_rating_incdec_width_px.setMaximum( new_value * 2 )
-            self._preview_window_rating_incdec_width_px.setMinimum( new_value * 0.5 )
+            self._preview_window_rating_incdec_height_px.setMaximum( new_value * 2 )
+            self._preview_window_rating_incdec_height_px.setMinimum( new_value * 0.5 )
             
             new_value = self._draw_thumbnail_rating_icon_size_px.value()
             
-            self._draw_thumbnail_rating_incdec_width_px.setMaximum( new_value * 2 )
-            self._draw_thumbnail_rating_incdec_width_px.setMinimum( new_value * 0.5 )
+            self._draw_thumbnail_rating_incdec_height_px.setMaximum( new_value * 2 )
+            self._draw_thumbnail_rating_incdec_height_px.setMinimum( new_value * 0.5 )
             
         
         def UpdateOptions( self ):
             
             self._new_options.SetFloat( 'media_viewer_rating_icon_size_px', self._media_viewer_rating_icon_size_px.value() )
-            self._new_options.SetFloat( 'media_viewer_rating_incdec_width_px', self._media_viewer_rating_incdec_width_px.value() )
+            self._new_options.SetFloat( 'media_viewer_rating_incdec_height_px', self._media_viewer_rating_incdec_height_px.value() )
             
             self._new_options.SetBoolean( 'draw_thumbnail_rating_background', self._draw_thumbnail_rating_background.isChecked() )
             self._new_options.SetBoolean( 'draw_thumbnail_numerical_ratings_collapsed_always', self._draw_thumbnail_numerical_ratings_collapsed_always.isChecked() )
             self._new_options.SetFloat( 'draw_thumbnail_rating_icon_size_px', self._draw_thumbnail_rating_icon_size_px.value() )
-            self._new_options.SetFloat( 'thumbnail_rating_incdec_width_px', self._draw_thumbnail_rating_incdec_width_px.value() )
+            self._new_options.SetFloat( 'thumbnail_rating_incdec_height_px', self._draw_thumbnail_rating_incdec_height_px.value() )
             
             self._new_options.SetFloat( 'preview_window_rating_icon_size_px', self._preview_window_rating_icon_size_px.value() )
-            self._new_options.SetFloat( 'preview_window_rating_incdec_width_px', self._preview_window_rating_incdec_width_px.value() )
+            self._new_options.SetFloat( 'preview_window_rating_incdec_height_px', self._preview_window_rating_incdec_height_px.value() )
             
             self._new_options.SetFloat( 'dialog_rating_icon_size_px', self._dialog_rating_icon_size_px.value() )
-            self._new_options.SetFloat( 'dialog_rating_incdec_width_px', self._dialog_rating_incdec_width_px.value() )
+            self._new_options.SetFloat( 'dialog_rating_incdec_height_px', self._dialog_rating_incdec_height_px.value() )
             
         
     


### PR DESCRIPTION
inc/dec rating size user-options are now 'height' instead of width. This means we're always doing *2 instead of /2 for the other default dimension which should be better to work with.
Width is now determined dynamically with additional padding for larger numbers starting at 4 digits long. anything <=999 uses the same sized box.
<img width="276" height="28" alt="image" src="https://github.com/user-attachments/assets/ad34fd5f-28f3-4b73-b980-bf3c36ad1678" />

Alternate padding method included that if swapped in code grows faster than digits:
<img width="315" height="27" alt="image-1" src="https://github.com/user-attachments/assets/ff3bac41-f513-4c1f-8490-2d8ea5b87955" />
