### PR TITLE
add selected files to get_page_info api

### DIFF
--- a/hydrus/client/media/ClientMedia.py
+++ b/hydrus/client/media/ClientMedia.py
@@ -1009,9 +1009,9 @@ class MediaList( object ):
         d[ 'hash_ids' ] = [ m.GetMediaResult().GetHashId() for m in flat_media ]
         
         selected_media = self.GetSelectedMedia()
-        flat_selected_media = FlattenMedia(selected_media)
+        flat_selected_media = FlattenMedia( selected_media )
         
-        d[ 'num_files_selected' ] = len(flat_selected_media)
+        d[ 'num_files_selected' ] = len( flat_selected_media )
         d[ 'hash_ids_selected' ] = [ m.GetMediaResult().GetHashId() for m in flat_selected_media ]
         
         if not simple:


### PR DESCRIPTION
closes #1583 and kind of #270

Adds to the `GET /manage_pages/get_page_info` api route information about the selected files, including the count and ids, and if it's not simple, also the hashes in the same way it already gives info about all the media in the page. This allows to directly get what the user has selected through the api rather than using hacks like triggering the hotkey for copying selected file hashes.

I have tested it and seems to work fine.