### PR TITLE
add `get_media_viewer` api route

### DIFF
--- a/hydrus/client/gui/ClientGUI.py
+++ b/hydrus/client/gui/ClientGUI.py
@@ -8049,6 +8049,53 @@ The password is cleartext here but obscured in the entry dialog. Enter a blank p
         self._canvas_frames = [ frame for frame in self._canvas_frames if QP.isValid( frame ) ]
         
     
+    def GetMediaViewerInfo( self ):
+        
+        self.MaintainCanvasFrameReferences()
+        
+        for frame in self._canvas_frames:
+            
+            if frame._canvas_window is not None:
+                
+                current_media = frame._canvas_window._current_media
+                
+                if current_media is not None:
+                    
+                    info = {}
+                    
+                    # Basic file info
+                    info[ 'hash' ] = current_media.GetHash()
+                    info[ 'size' ] = current_media.GetSize()
+                    info[ 'mime' ] = current_media.GetMime()
+                    info[ 'width' ], info[ 'height' ] = current_media.GetResolution()
+                    info[ 'duration' ] = current_media.GetDurationMS()
+                    info[ 'num_frames' ] = current_media.GetNumFrames()
+                    info[ 'has_audio' ] = current_media.HasAudio()
+                    info[ 'is_inbox' ] = current_media.HasInbox()
+                    
+                    # Extended file info from FileInfoManager
+                    file_info_manager = current_media.GetFileInfoManager()
+                    info[ 'has_exif' ] = file_info_manager.has_exif
+                    info[ 'has_icc_profile' ] = file_info_manager.has_icc_profile
+                    info[ 'has_transparency' ] = file_info_manager.has_transparency
+                    info[ 'blurhash' ] = file_info_manager.blurhash
+                    info[ 'pixel_hash' ] = file_info_manager.pixel_hash
+                    
+                    # Notes
+                    info[ 'has_notes' ] = current_media.HasNotes()
+                    
+                    # URLs from LocationsManager
+                    locations_manager = current_media.GetLocationsManager()
+                    info[ 'urls' ] = list( locations_manager.GetURLs() )
+                    
+                    return info
+                    
+                
+            
+        
+        return None
+        
+    
     def MaintainMemory( self ):
         
         self._menu_updater_database.update()

--- a/hydrus/client/networking/api/ClientLocalServer.py
+++ b/hydrus/client/networking/api/ClientLocalServer.py
@@ -172,6 +172,7 @@ class HydrusServiceClientAPI( HydrusClientService ):
         manage_pages.putChild( b'get_pages', ClientLocalServerResourcesManagePages.HydrusResourceClientAPIRestrictedManagePagesGetPages( self._service, self._client_requests_domain ) )
         manage_pages.putChild( b'get_page_info', ClientLocalServerResourcesManagePages.HydrusResourceClientAPIRestrictedManagePagesGetPageInfo( self._service, self._client_requests_domain ) )
         manage_pages.putChild( b'refresh_page', ClientLocalServerResourcesManagePages.HydrusResourceClientAPIRestrictedManagePagesRefreshPage( self._service, self._client_requests_domain ) )
+        manage_pages.putChild( b'get_media_viewer', ClientLocalServerResourcesManagePages.HydrusResourceClientAPIRestrictedManagePagesGetMediaViewer( self._service, self._client_requests_domain ) )
         
         manage_popups = notFound()
         

--- a/hydrus/client/networking/api/ClientLocalServerResourcesManagePages.py
+++ b/hydrus/client/networking/api/ClientLocalServerResourcesManagePages.py
@@ -165,3 +165,52 @@ class HydrusResourceClientAPIRestrictedManagePagesRefreshPage( HydrusResourceCli
         return response_context
         
     
+
+class HydrusResourceClientAPIRestrictedManagePagesGetMediaViewer( HydrusResourceClientAPIRestrictedManagePages ):
+    
+    def _threadDoGETJob( self, request: HydrusServerRequest.HydrusRequest ):
+        
+        from hydrus.core import HydrusConstants as HC
+        
+        def do_it():
+            
+            return CG.client_controller.gui.GetMediaViewerInfo()
+            
+        
+        file_info = CG.client_controller.CallBlockingToQtTLW( do_it )
+        
+        if file_info is None:
+            
+            raise HydrusExceptions.NotFoundException( 'No media viewer is currently open or no file is being viewed!' )
+            
+        
+        media_viewer_file = {
+            'hash': file_info[ 'hash' ].hex(),
+            'size': file_info[ 'size' ],
+            'mime': HC.mime_string_lookup.get( file_info[ 'mime' ], 'unknown' ),
+            'width': file_info[ 'width' ],
+            'height': file_info[ 'height' ],
+            'duration': file_info[ 'duration' ],
+            'num_frames': file_info[ 'num_frames' ],
+            'has_audio': file_info[ 'has_audio' ],
+            'is_inbox': file_info[ 'is_inbox' ],
+            'has_exif': file_info[ 'has_exif' ],
+            'has_icc_profile': file_info[ 'has_icc_profile' ],
+            'has_transparency': file_info[ 'has_transparency' ],
+            'blurhash': file_info[ 'blurhash' ],
+            'pixel_hash': file_info[ 'pixel_hash' ].hex() if file_info[ 'pixel_hash' ] is not None else None,
+            'has_notes': file_info[ 'has_notes' ],
+            'urls': file_info[ 'urls' ]
+        }
+        
+        body_dict = {
+            'media_viewer_file': media_viewer_file
+        }
+        
+        body = ClientLocalServerCore.Dumps( body_dict, request.preferred_mime )
+        
+        response_context = HydrusServerResources.ResponseContext( 200, mime = request.preferred_mime, body = body )
+        
+        return response_context
+        
+    


### PR DESCRIPTION
Following #1896, with this change it is now possible to get through the api what the user has selected, either in the media viewer or in a page. While I was at it, I added more useful info that was readily available to the response.

Finally closes #1583